### PR TITLE
fix(docker): Use --only main instead of --no-dev in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ ADD pyproject.toml pyproject.toml
 ADD poetry.lock poetry.lock
 
 # Install dependencies
-RUN poetry config virtualenvs.create false && poetry install --no-root --no-dev
+RUN poetry config virtualenvs.create false && poetry install --no-root --only main
 
 CMD [ "poetry", "run", "fastapi", "run", "./app/main.py", "--port", "80" ]


### PR DESCRIPTION
The `--no-dev` flag is not a valid option for `poetry install` in the version of poetry being used. This commit updates the `Dockerfile` to use the correct `--only main` flag to install only the main dependencies.