### PR TITLE
🧹 [code health] Move module level import to top in app/models.py

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,9 +1,9 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 class BoggleClass(BaseModel):
     size: int
-
-from typing import Optional
 
 class MessageClass(BaseModel):
     message: str


### PR DESCRIPTION
This PR improves the code health of `app/models.py` by moving a module-level import that was previously located between class definitions to the top of the file, as per PEP 8 guidelines.

🎯 **What:** Moved `from typing import Optional` to the top of `app/models.py`.
💡 **Why:** Improves maintainability and readability by following standard Python import conventions (PEP 8).
✅ **Verification:** Performed syntax checks using `ast.parse` and `compileall` to ensure no errors were introduced. The environment lacked full dependencies to run the entire test suite, but the changes are purely organizational and safe.
✨ **Result:** Cleaned up import structure in `app/models.py`.

---
*PR created automatically by Jules for task [17059620385034371590](https://jules.google.com/task/17059620385034371590) started by @qsig-a*