### PR TITLE
🧹 Remove unused `Any` import in `app/main.py`

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import List, Dict, Any, Callable, Awaitable, TypeVar, Optional
+from typing import List, Dict, Callable, Awaitable, TypeVar, Optional
 
 from fastapi import FastAPI, HTTPException, BackgroundTasks, Depends, Request
 from contextlib import asynccontextmanager


### PR DESCRIPTION
🎯 **What:** Removed the unused `Any` import from the `typing` module on line 5 of `app/main.py`.
💡 **Why:** Having unused imports clutters the codebase, increases the risk of naming collisions, and marginally impacts startup performance. Removing it keeps the file clean and readable.
✅ **Verification:** Verified that `Any` is not used anywhere else in `app/main.py`. Used `python -m compileall app/main.py` to ensure there are no syntax errors since full dependencies couldn't be loaded for `pytest`.
✨ **Result:** A slightly cleaner and more maintainable `app/main.py` file with no change in functionality.

---
*PR created automatically by Jules for task [400800446520810332](https://jules.google.com/task/400800446520810332) started by @qsig-a*