### PR TITLE
🧪 Add tests for get_random_art endpoint

### DIFF
--- a/tests/test_art_endpoint.py
+++ b/tests/test_art_endpoint.py
@@ -2,39 +2,57 @@ import pytest
 from unittest.mock import patch, AsyncMock
 from fastapi.testclient import TestClient
 from app.config import Settings
-import asyncio
+from fastapi import HTTPException
+import app.sayings.sayings as say
 
-@patch("app.main.asyncio.to_thread", new_callable=AsyncMock)
-@pytest.mark.asyncio
-async def test_get_art_success(
-    mock_to_thread: AsyncMock,
+@patch("app.main.get_and_send_art", new_callable=AsyncMock)
+def test_get_random_art_success(
+    mock_get_and_send_art: AsyncMock,
     client: TestClient,
     mock_settings: Settings,
     mock_vestaboard_connector: AsyncMock
 ):
-    mock_settings.saying_db_enable = "1"
-    test_art = [[1, 2], [3, 4]]
-    test_title = "Test Art Title"
-
-    mock_to_thread.return_value = (test_art, test_title)
+    """Tests successful random art retrieval and sending by mocking get_and_send_art."""
+    expected_response = {"message": "Random art queued", "title": "Test Title"}
+    mock_get_and_send_art.return_value = expected_response
 
     response = client.get("/art")
 
     assert response.status_code == 200
-    assert response.json() == {"message": "Random art queued", "title": test_title}
-    mock_vestaboard_connector.send_array.assert_called_once_with(test_art, source='rw')
+    assert response.json() == expected_response
 
-@patch("app.main.asyncio.to_thread", new_callable=AsyncMock)
-@pytest.mark.asyncio
-async def test_get_art_not_found(
-    mock_to_thread: AsyncMock,
-    client: TestClient,
-    mock_settings: Settings
+    # Verify get_and_send_art was called with the correct parameters
+    mock_get_and_send_art.assert_called_once_with(
+        art_func=say.GetSingleRandArt,
+        success_message="Random art queued",
+        error_message="Error getting art",
+        settings=mock_settings,
+        connector=mock_vestaboard_connector,
+        source='rw'
+    )
+
+@patch("app.main.get_and_send_art", new_callable=AsyncMock)
+def test_get_random_art_not_found(
+    mock_get_and_send_art: AsyncMock,
+    client: TestClient
 ):
-    mock_settings.saying_db_enable = "1"
-    mock_to_thread.return_value = None
+    """Tests art endpoint when get_and_send_art raises 404."""
+    mock_get_and_send_art.side_effect = HTTPException(status_code=404, detail="Error getting art: Art not found or DB disabled")
 
     response = client.get("/art")
 
     assert response.status_code == 404
     assert "Error getting art: Art not found or DB disabled" in response.json()["detail"]
+
+@patch("app.main.get_and_send_art", new_callable=AsyncMock)
+def test_get_random_art_internal_error(
+    mock_get_and_send_art: AsyncMock,
+    client: TestClient
+):
+    """Tests art endpoint when get_and_send_art raises 500."""
+    mock_get_and_send_art.side_effect = HTTPException(status_code=500, detail="Error getting art: An unexpected internal error occurred")
+
+    response = client.get("/art")
+
+    assert response.status_code == 500
+    assert "Error getting art: An unexpected internal error occurred" in response.json()["detail"]


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing tests for the `get_random_art` endpoint in `app/main.py`.
📊 **Coverage:** What scenarios are now tested:
- Successful art retrieval and queueing.
- Handling of 404 Not Found from the `get_and_send_art` function.
- Handling of 500 Internal Error from the `get_and_send_art` function.
✨ **Result:** The improvement in test coverage: Replaced old `asyncio.to_thread` mock tests with clear validation that `get_random_art` interacts correctly with the `get_and_send_art` helper.

---
*PR created automatically by Jules for task [2264832700601101197](https://jules.google.com/task/2264832700601101197) started by @qsig-a*