### PR TITLE
🧪 Add tests for post_message_local endpoint

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -499,3 +499,83 @@ def test_get_quote_unexpected_error(
     response = client.get(endpoint_path)
     assert response.status_code == 500
     assert f"{expected_error_msg_prefix}: An unexpected internal error occurred" in response.json()["detail"]
+
+# --- Tests for POST /message/local endpoint ---
+def test_post_message_local_success(client: TestClient, mock_vestaboard_connector: AsyncMock):
+    """Tests successful message posting via Local API."""
+    test_message = "Hello Local Vestaboard"
+    response = client.post("/message/local", json={"message": test_message})
+    assert response.status_code == 200
+    assert response.json() == {"message": "Message sent successfully (Local)"}
+    mock_vestaboard_connector.send_message.assert_called_once_with(
+        test_message,
+        source='local',
+        strategy=None,
+        step_interval_ms=None,
+        step_size=None
+    )
+
+def test_post_message_local_with_transitions(client: TestClient, mock_vestaboard_connector: AsyncMock):
+    """Tests posting a message via Local API with transition parameters."""
+    test_message = "Transition Local"
+    strategy = "column"
+    step_interval_ms = 3000
+    step_size = 2
+    response = client.post("/message/local", json={
+        "message": test_message,
+        "strategy": strategy,
+        "step_interval_ms": step_interval_ms,
+        "step_size": step_size
+    })
+    assert response.status_code == 200
+    assert response.json() == {"message": "Message sent successfully (Local)"}
+    mock_vestaboard_connector.send_message.assert_called_once_with(
+        test_message,
+        source='local',
+        strategy=strategy,
+        step_interval_ms=step_interval_ms,
+        step_size=step_size
+    )
+
+def test_post_message_local_empty_payload(client: TestClient):
+    """Tests posting an empty message via Local API."""
+    response = client.post("/message/local", json={"message": ""})
+    assert response.status_code == 400
+    # Current main.py logic raises HTTPException(400) before model validation for empty string
+
+def test_post_message_local_no_content_provided(client: TestClient):
+    """Tests posting with no message content, which should be caught by pydantic model via Local API."""
+    response = client.post("/message/local", json={}) # Empty JSON
+    assert response.status_code == 422 # Unprocessable Entity due to Pydantic validation
+
+def test_post_message_local_invalid_chars_error(client: TestClient, mock_vestaboard_connector: AsyncMock):
+    """Tests VestaboardInvalidCharsError handling via Local API."""
+    test_message = "Invalid char ~"
+    mock_vestaboard_connector.send_message.side_effect = VestaboardInvalidCharsError("Invalid character")
+    response = client.post("/message/local", json={"message": test_message})
+    assert response.status_code == 422
+    assert "Error sending message: Invalid characters. Invalid character" in response.json()["detail"]
+
+def test_post_message_local_auth_error(client: TestClient, mock_vestaboard_connector: AsyncMock):
+    """Tests VestaboardAuthError handling via Local API."""
+    test_message = "Auth error test"
+    mock_vestaboard_connector.send_message.side_effect = VestaboardAuthError("Auth failed")
+    response = client.post("/message/local", json={"message": test_message})
+    assert response.status_code == 503
+    assert "Error sending message: Vestaboard authentication error." in response.json()["detail"]
+
+def test_post_message_local_general_vestaboard_error(client: TestClient, mock_vestaboard_connector: AsyncMock):
+    """Tests general VestaboardError handling via Local API."""
+    test_message = "General error test"
+    mock_vestaboard_connector.send_message.side_effect = VestaboardError("API error")
+    response = client.post("/message/local", json={"message": test_message})
+    assert response.status_code == 502
+    assert "Error sending message: Error communicating with Vestaboard." in response.json()["detail"]
+
+def test_post_message_local_unexpected_error(client: TestClient, mock_vestaboard_connector: AsyncMock):
+    """Tests handling of unexpected errors during message posting via Local API."""
+    test_message = "Unexpected error test"
+    mock_vestaboard_connector.send_message.side_effect = Exception("Something broke")
+    response = client.post("/message/local", json={"message": test_message})
+    assert response.status_code == 500
+    assert "Error sending message: An unexpected internal error occurred." in response.json()["detail"]


### PR DESCRIPTION
🎯 **What:** The `post_message_local` endpoint in `app/main.py` was missing test coverage.
📊 **Coverage:** Added tests in `tests/test_main.py` to cover:
  - Successful message sending.
  - Successful message sending with transition parameters (`strategy`, `step_interval_ms`, `step_size`).
  - Handling of empty string payloads (returns 400).
  - Handling of missing content (returns 422).
  - Vestaboard exceptions: `VestaboardInvalidCharsError`, `VestaboardAuthError`, `VestaboardError`, and generic unexpected errors.
✨ **Result:** Improved test coverage and reliability for the Local API message posting endpoint, ensuring all edge cases and expected behaviors are validated.

---
*PR created automatically by Jules for task [17914572733663897207](https://jules.google.com/task/17914572733663897207) started by @qsig-a*