### PR TITLE
🧪 Add missing tests for get_nsfw_quote_local endpoint

### DIFF
--- a/tests/test_nsfw_quote_local.py
+++ b/tests/test_nsfw_quote_local.py
@@ -1,0 +1,69 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from fastapi.testclient import TestClient
+from app.config import Settings
+from fastapi import HTTPException
+import app.sayings.sayings as say
+
+@pytest.mark.parametrize(
+    "endpoint_path, strategy, step_interval_ms, step_size",
+    [
+        ("/nsfw_quote/local", None, None, None),
+        ("/nsfw_quote/local?strategy=column&step_interval_ms=1000&step_size=2", "column", 1000, 2),
+    ]
+)
+@patch("app.main.get_and_send_quote", new_callable=AsyncMock)
+def test_get_nsfw_quote_local_success(
+    mock_get_and_send_quote: AsyncMock,
+    endpoint_path: str,
+    strategy: str | None,
+    step_interval_ms: int | None,
+    step_size: int | None,
+    client: TestClient,
+    mock_settings: Settings,
+    mock_vestaboard_connector: AsyncMock
+):
+    """Tests successful NSFW quote retrieval and sending via Local API by mocking get_and_send_quote."""
+    expected_response = {"message": "Random NSFW quote queued (Local)"}
+    mock_get_and_send_quote.return_value = expected_response
+
+    response = client.get(endpoint_path)
+
+    assert response.status_code == 200
+    assert response.json() == expected_response
+
+    # Verify get_and_send_quote was called with the correct parameters
+    mock_get_and_send_quote.assert_called_once()
+    kwargs = mock_get_and_send_quote.call_args.kwargs
+    assert kwargs.get("quote_func") == say.GetSingleRandNsfwS
+    assert kwargs.get("success_message") == "Random NSFW quote queued (Local)"
+    assert kwargs.get("error_message") == "Error getting NSFW quote"
+    assert kwargs.get("settings") == mock_settings
+    assert kwargs.get("connector") == mock_vestaboard_connector
+    assert kwargs.get("source") == 'local'
+
+@patch("app.main.get_and_send_quote", new_callable=AsyncMock)
+def test_get_nsfw_quote_local_not_found(
+    mock_get_and_send_quote: AsyncMock,
+    client: TestClient
+):
+    """Tests NSFW quote local endpoint when get_and_send_quote raises 404."""
+    mock_get_and_send_quote.side_effect = HTTPException(status_code=404, detail="Error getting NSFW quote: Quote not found or DB disabled")
+
+    response = client.get("/nsfw_quote/local")
+
+    assert response.status_code == 404
+    assert "Error getting NSFW quote: Quote not found or DB disabled" in response.json()["detail"]
+
+@patch("app.main.get_and_send_quote", new_callable=AsyncMock)
+def test_get_nsfw_quote_local_error(
+    mock_get_and_send_quote: AsyncMock,
+    client: TestClient
+):
+    """Tests NSFW quote local endpoint when get_and_send_quote raises 500."""
+    mock_get_and_send_quote.side_effect = HTTPException(status_code=500, detail="Error getting NSFW quote: An unexpected internal error occurred")
+
+    response = client.get("/nsfw_quote/local")
+
+    assert response.status_code == 500
+    assert "Error getting NSFW quote: An unexpected internal error occurred" in response.json()["detail"]


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `get_nsfw_quote_local` endpoint in `app/main.py` lacked unit tests.

📊 **Coverage:** What scenarios are now tested
- **Happy Path:** Successfully retrieving and queuing a random NSFW quote via the Local API (`200 OK`).
- **Not Found/Disabled:** Handling the case where the saying DB is disabled or no quote is found (`404 Not Found`).
- **Internal Error:** Handling unexpected internal errors during the quote retrieval process (`500 Internal Server Error`).

✨ **Result:** The improvement in test coverage
The test suite now robustly covers the `get_nsfw_quote_local` endpoint, ensuring it correctly integrates with `get_and_send_quote` and `app.sayings.sayings.GetSingleRandNsfwS`, improving overall reliability.

---
*PR created automatically by Jules for task [6614862159773656962](https://jules.google.com/task/6614862159773656962) started by @qsig-a*