### PR TITLE
🧹 [code health] Remove unused Optional import

### DIFF
--- a/app/connectors/vestaboard.py
+++ b/app/connectors/vestaboard.py
@@ -3,7 +3,7 @@
 import httpx
 import re
 import logging
-from typing import Optional, List, Dict, Any, Union
+from typing import List, Dict, Any, Union
 
 # Import central settings configuration
 from app.config import Settings


### PR DESCRIPTION
🎯 **What:** Removed unused `Optional` import from `typing` module in `app/connectors/vestaboard.py`.
💡 **Why:** Cleans up code health by removing an unused dependency which can slightly improve readability and maintainability.
✅ **Verification:** Ran `poetry run pytest` to run the full test suite. 86 tests passed with no new errors. Also used the `request_code_review` tool which approved the change as safe and straightforward.
✨ **Result:** A slightly cleaner file with no unused imports.

---
*PR created automatically by Jules for task [14632048351155754125](https://jules.google.com/task/14632048351155754125) started by @qsig-a*