### PR TITLE
🧹 Remove unnecessary f-string prefix in vestaboard.py

### DIFF
--- a/app/connectors/vestaboard.py
+++ b/app/connectors/vestaboard.py
@@ -168,7 +168,7 @@ class VestaboardConnector:
         string_text = str(text)
         if not VALID_CHARS_REGEX.match(string_text):
              log.warning(f"Message contains invalid characters: '{string_text}'")
-             raise VestaboardInvalidCharsError(f"Message contains invalid characters.")
+             raise VestaboardInvalidCharsError("Message contains invalid characters.")
 
         if source == 'local':
             # Local API only accepts arrays


### PR DESCRIPTION
🎯 **What:** Removed an unnecessary `f` prefix from a string literal in `app/connectors/vestaboard.py`.
💡 **Why:** This string literal didn't contain any interpolation (no variables were being passed into it), so the `f` prefix was redundant and adds visual noise.
✅ **Verification:** Verified by checking that `poetry run pytest` succeeds and that the behavior of the application is unchanged since this is purely a syntax cleanup.
✨ **Result:** Improved the cleanliness and readability of the code without altering its underlying logic.

---
*PR created automatically by Jules for task [18213013141639797285](https://jules.google.com/task/18213013141639797285) started by @qsig-a*