### PR TITLE
🧹 [code health improvement] Refactor `get_and_send_quote` and `get_and_send_art` to use `ActionConfig` dataclass

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from typing import List, Dict, Callable, Awaitable, TypeVar, Optional
 
 from fastapi import FastAPI, HTTPException, BackgroundTasks, Depends, Request
@@ -22,6 +23,12 @@ log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 T = TypeVar('T')
+
+@dataclass
+class ActionConfig:
+    success_message: str
+    error_message: str
+    source: str = 'rw'
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -82,48 +89,44 @@ async def handle_vestaboard_action(
 
 async def get_and_send_quote(
     quote_func: Callable[[Settings], str | None],
-    success_message: str,
-    error_message: str,
+    config: ActionConfig,
     settings: Settings,
     connector: VestaboardConnector,
-    source: str = 'rw',
     **kwargs
 ) -> Dict[str, str]:
     try:
         data = await asyncio.to_thread(quote_func, settings=settings)
         if data is None:
-            log.warning(f"{error_message}: Quote function returned None (DB disabled or no quote found).")
-            raise HTTPException(status_code=404, detail=f"{error_message}: Quote not found or DB disabled")
+            log.warning(f"{config.error_message}: Quote function returned None (DB disabled or no quote found).")
+            raise HTTPException(status_code=404, detail=f"{config.error_message}: Quote not found or DB disabled")
 
         await handle_vestaboard_action(
-            lambda: connector.send_message(data, source=source, **kwargs),
-            error_message
+            lambda: connector.send_message(data, source=config.source, **kwargs),
+            config.error_message
         )
-        log.info(f"Successfully sent quote to board: {success_message}")
-        return {"message": success_message}
+        log.info(f"Successfully sent quote to board: {config.success_message}")
+        return {"message": config.success_message}
     except HTTPException:
         raise
     except ConnectionError as e:
         log.error(f"Database connection error getting quote: {e}", exc_info=True)
-        raise HTTPException(status_code=503, detail=f"{error_message}: Database unavailable")
+        raise HTTPException(status_code=503, detail=f"{config.error_message}: Database unavailable")
     except Exception as e:
         log.exception(f"Unexpected error in quote process: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"{error_message}: An unexpected internal error occurred")
+        raise HTTPException(status_code=500, detail=f"{config.error_message}: An unexpected internal error occurred")
 
 async def get_and_send_art(
     art_func: Callable[[Settings], List[List[int]] | tuple[List[List[int]], str] | None],
-    success_message: str,
-    error_message: str,
+    config: ActionConfig,
     settings: Settings,
     connector: VestaboardConnector,
-    source: str = 'rw',
     **kwargs
 ) -> Dict[str, str]:
     try:
         result = await asyncio.to_thread(art_func, settings=settings)
         if result is None:
-            log.warning(f"{error_message}: Art function returned None (DB disabled or no art found).")
-            raise HTTPException(status_code=404, detail=f"{error_message}: Art not found or DB disabled")
+            log.warning(f"{config.error_message}: Art function returned None (DB disabled or no art found).")
+            raise HTTPException(status_code=404, detail=f"{config.error_message}: Art not found or DB disabled")
 
         title = "Unknown"
         if isinstance(result, tuple):
@@ -134,19 +137,19 @@ async def get_and_send_art(
             data = result
 
         await handle_vestaboard_action(
-            lambda: connector.send_array(data, source=source, **kwargs),
-            error_message
+            lambda: connector.send_array(data, source=config.source, **kwargs),
+            config.error_message
         )
-        log.info(f"Successfully sent art to board: {success_message}")
-        return {"message": success_message, "title": title}
+        log.info(f"Successfully sent art to board: {config.success_message}")
+        return {"message": config.success_message, "title": title}
     except HTTPException:
         raise
     except ConnectionError as e:
         log.error(f"Database connection error getting art: {e}", exc_info=True)
-        raise HTTPException(status_code=503, detail=f"{error_message}: Database unavailable")
+        raise HTTPException(status_code=503, detail=f"{config.error_message}: Database unavailable")
     except Exception as e:
         log.exception(f"Unexpected error in art process: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"{error_message}: An unexpected internal error occurred")
+        raise HTTPException(status_code=500, detail=f"{config.error_message}: An unexpected internal error occurred")
 
 
 @app.post("/games/boggle", status_code=202)
@@ -189,11 +192,13 @@ async def get_sfw_quote(
 ) -> Dict[str, str]:
     return await get_and_send_quote(
         quote_func=say.GetSingleRandSfwS,
-        success_message="Random SFW quote queued",
-        error_message="Error getting SFW quote",
+        config=ActionConfig(
+            success_message="Random SFW quote queued",
+            error_message="Error getting SFW quote",
+            source='rw'
+        ),
         settings=settings,
-        connector=connector,
-        source='rw'
+        connector=connector
     )
 
 @app.get("/sfw_quote/local")
@@ -206,11 +211,13 @@ async def get_sfw_quote_local(
 ) -> Dict[str, str]:
     return await get_and_send_quote(
         quote_func=say.GetSingleRandSfwS,
-        success_message="Random SFW quote queued (Local)",
-        error_message="Error getting SFW quote",
+        config=ActionConfig(
+            success_message="Random SFW quote queued (Local)",
+            error_message="Error getting SFW quote",
+            source='local'
+        ),
         settings=settings,
         connector=connector,
-        source='local',
         strategy=strategy,
         step_interval_ms=step_interval_ms,
         step_size=step_size
@@ -223,11 +230,13 @@ async def get_nsfw_quote(
 ) -> Dict[str, str]:
     return await get_and_send_quote(
         quote_func=say.GetSingleRandNsfwS,
-        success_message="Random NSFW quote queued",
-        error_message="Error getting NSFW quote",
+        config=ActionConfig(
+            success_message="Random NSFW quote queued",
+            error_message="Error getting NSFW quote",
+            source='rw'
+        ),
         settings=settings,
-        connector=connector,
-        source='rw'
+        connector=connector
     )
 
 @app.get("/nsfw_quote/local")
@@ -240,11 +249,13 @@ async def get_nsfw_quote_local(
 ) -> Dict[str, str]:
     return await get_and_send_quote(
         quote_func=say.GetSingleRandNsfwS,
-        success_message="Random NSFW quote queued (Local)",
-        error_message="Error getting NSFW quote",
+        config=ActionConfig(
+            success_message="Random NSFW quote queued (Local)",
+            error_message="Error getting NSFW quote",
+            source='local'
+        ),
         settings=settings,
         connector=connector,
-        source='local',
         strategy=strategy,
         step_interval_ms=step_interval_ms,
         step_size=step_size
@@ -257,11 +268,13 @@ async def get_random_art(
 ) -> Dict[str, str]:
     return await get_and_send_art(
         art_func=say.GetSingleRandArt,
-        success_message="Random art queued",
-        error_message="Error getting art",
+        config=ActionConfig(
+            success_message="Random art queued",
+            error_message="Error getting art",
+            source='rw'
+        ),
         settings=settings,
-        connector=connector,
-        source='rw'
+        connector=connector
     )
 
 @app.get("/art/local")
@@ -274,11 +287,13 @@ async def get_random_art_local(
 ) -> Dict[str, str]:
     return await get_and_send_art(
         art_func=say.GetSingleRandArt,
-        success_message="Random art queued (Local)",
-        error_message="Error getting art",
+        config=ActionConfig(
+            success_message="Random art queued (Local)",
+            error_message="Error getting art",
+            source='local'
+        ),
         settings=settings,
         connector=connector,
-        source='local',
         strategy=strategy,
         step_interval_ms=step_interval_ms,
         step_size=step_size

--- a/tests/test_art_endpoint.py
+++ b/tests/test_art_endpoint.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException
 from app.config import Settings
 from fastapi import HTTPException
 import app.sayings.sayings as say
+from app.main import ActionConfig
 
 @patch("app.main.get_and_send_art", new_callable=AsyncMock)
 def test_get_random_art_success(
@@ -25,11 +26,13 @@ def test_get_random_art_success(
     # Verify get_and_send_art was called with the correct parameters
     mock_get_and_send_art.assert_called_once_with(
         art_func=say.GetSingleRandArt,
-        success_message="Random art queued",
-        error_message="Error getting art",
+        config=ActionConfig(
+            success_message="Random art queued",
+            error_message="Error getting art",
+            source='rw'
+        ),
         settings=mock_settings,
-        connector=mock_vestaboard_connector,
-        source='rw'
+        connector=mock_vestaboard_connector
     )
 
 @patch("app.main.get_and_send_art", new_callable=AsyncMock)
@@ -75,11 +78,13 @@ def test_get_random_art_local_success(
 
     mock_get_and_send_art.assert_called_once_with(
         art_func=say.GetSingleRandArt,
-        success_message="Random art queued (Local)",
-        error_message="Error getting art",
+        config=ActionConfig(
+            success_message="Random art queued (Local)",
+            error_message="Error getting art",
+            source='local'
+        ),
         settings=mock_settings,
         connector=mock_vestaboard_connector,
-        source="local",
         strategy=None,
         step_interval_ms=None,
         step_size=None
@@ -102,11 +107,13 @@ def test_get_random_art_local_success_with_params(
 
     mock_get_and_send_art.assert_called_once_with(
         art_func=say.GetSingleRandArt,
-        success_message="Random art queued (Local)",
-        error_message="Error getting art",
+        config=ActionConfig(
+            success_message="Random art queued (Local)",
+            error_message="Error getting art",
+            source='local'
+        ),
         settings=mock_settings,
         connector=mock_vestaboard_connector,
-        source="local",
         strategy="column",
         step_interval_ms=1000,
         step_size=2

--- a/tests/test_nsfw_quote.py
+++ b/tests/test_nsfw_quote.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from app.config import Settings
 from fastapi import HTTPException
 import app.sayings.sayings as say
+from app.main import ActionConfig
 
 @patch("app.main.get_and_send_quote", new_callable=AsyncMock)
 def test_get_nsfw_quote_success(
@@ -24,11 +25,13 @@ def test_get_nsfw_quote_success(
     # Verify get_and_send_quote was called with the correct parameters
     mock_get_and_send_quote.assert_called_once_with(
         quote_func=say.GetSingleRandNsfwS,
-        success_message="Random NSFW quote queued",
-        error_message="Error getting NSFW quote",
+        config=ActionConfig(
+            success_message="Random NSFW quote queued",
+            error_message="Error getting NSFW quote",
+            source='rw'
+        ),
         settings=mock_settings,
-        connector=mock_vestaboard_connector,
-        source='rw'
+        connector=mock_vestaboard_connector
     )
 
 @patch("app.main.get_and_send_quote", new_callable=AsyncMock)

--- a/tests/test_nsfw_quote_local.py
+++ b/tests/test_nsfw_quote_local.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from app.config import Settings
 from fastapi import HTTPException
 import app.sayings.sayings as say
+from app.main import ActionConfig
 
 @pytest.mark.parametrize(
     "endpoint_path, strategy, step_interval_ms, step_size",
@@ -36,11 +37,13 @@ def test_get_nsfw_quote_local_success(
     mock_get_and_send_quote.assert_called_once()
     kwargs = mock_get_and_send_quote.call_args.kwargs
     assert kwargs.get("quote_func") == say.GetSingleRandNsfwS
-    assert kwargs.get("success_message") == "Random NSFW quote queued (Local)"
-    assert kwargs.get("error_message") == "Error getting NSFW quote"
+    assert kwargs.get("config") == ActionConfig(
+        success_message="Random NSFW quote queued (Local)",
+        error_message="Error getting NSFW quote",
+        source='local'
+    )
     assert kwargs.get("settings") == mock_settings
     assert kwargs.get("connector") == mock_vestaboard_connector
-    assert kwargs.get("source") == 'local'
 
 @patch("app.main.get_and_send_quote", new_callable=AsyncMock)
 def test_get_nsfw_quote_local_not_found(

--- a/tests/test_sfw_quote.py
+++ b/tests/test_sfw_quote.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from app.config import Settings
 from fastapi import HTTPException
 import app.sayings.sayings as say
+from app.main import ActionConfig
 
 @patch("app.main.get_and_send_quote", new_callable=AsyncMock)
 def test_get_sfw_quote_success(
@@ -23,11 +24,13 @@ def test_get_sfw_quote_success(
 
     mock_get_and_send_quote.assert_called_once_with(
         quote_func=say.GetSingleRandSfwS,
-        success_message="Random SFW quote queued",
-        error_message="Error getting SFW quote",
+        config=ActionConfig(
+            success_message="Random SFW quote queued",
+            error_message="Error getting SFW quote",
+            source='rw'
+        ),
         settings=mock_settings,
-        connector=mock_vestaboard_connector,
-        source='rw'
+        connector=mock_vestaboard_connector
     )
 
 @patch("app.main.get_and_send_quote", new_callable=AsyncMock)

--- a/tests/test_sfw_quote_local.py
+++ b/tests/test_sfw_quote_local.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, AsyncMock
 from fastapi.testclient import TestClient
 from app.config import Settings
 from fastapi import HTTPException
+from app.main import ActionConfig
 
 @pytest.mark.parametrize(
     "endpoint_path, strategy, step_interval_ms, step_size",
@@ -35,11 +36,13 @@ def test_get_sfw_quote_local_success(
     import app.sayings.sayings as say
     mock_get_and_send_quote.assert_called_once_with(
         quote_func=say.GetSingleRandSfwS,
-        success_message="Random SFW quote queued (Local)",
-        error_message="Error getting SFW quote",
+        config=ActionConfig(
+            success_message="Random SFW quote queued (Local)",
+            error_message="Error getting SFW quote",
+            source='local'
+        ),
         settings=mock_settings,
         connector=mock_vestaboard_connector,
-        source='local',
         strategy=strategy,
         step_interval_ms=step_interval_ms,
         step_size=step_size


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The "Too many parameters" issue in `get_and_send_quote` and `get_and_send_art` located in `app/main.py` was resolved. These functions originally accepted 7 parameters.

💡 **Why:** How this improves maintainability
By grouping `success_message`, `error_message`, and `source` into an `ActionConfig` dataclass, the function signatures are streamlined, making them easier to read and less prone to argument order mistakes. It improves encapsulation of message-related configs.

✅ **Verification:** How you confirmed the change is safe
- Updated all call sites in `app/main.py`.
- Updated all relevant tests in `tests/test_sfw_quote.py`, `tests/test_nsfw_quote.py`, `tests/test_sfw_quote_local.py`, `tests/test_nsfw_quote_local.py`, and `tests/test_art_endpoint.py`.
- Ran the full test suite (`poetry run pytest`), which passed without errors.
- Verified there are no behavioral changes by keeping the exact same strings in configuration.

✨ **Result:** The improvement achieved
Reduced the parameter count in `get_and_send_quote` and `get_and_send_art` to 5 parameters, adhering to common clean code standards, while increasing clarity.

---
*PR created automatically by Jules for task [7732445025713262028](https://jules.google.com/task/7732445025713262028) started by @qsig-a*