### PR TITLE
🔒 fix: mitigate SQL injection risk in dynamic table and column queries

### DIFF
--- a/app/sayings/sayings.py
+++ b/app/sayings/sayings.py
@@ -13,6 +13,12 @@ log = logging.getLogger(__name__)
 
 _connection_pool = None
 
+ALLOWED_TABLES = {
+    "sfw_quotes": {"id", "quote", "source"},
+    "nsfw_quotes": {"id", "quote", "source"},
+    "art": {"id", "art_data", "title"},
+}
+
 def init_db_pool(settings: Settings):
     """Initializes the MySQL connection pool."""
     global _connection_pool
@@ -111,6 +117,11 @@ def _db_connection(settings: Settings):
 
 def _fetch_column_from_table(table_name: str, column_name: str, settings: Settings) -> str | None:
     """Fetches a random value from a given table and column using a managed DB connection."""
+    if table_name not in ALLOWED_TABLES:
+        raise ValueError(f"Invalid table name: {table_name}")
+    if column_name not in ALLOWED_TABLES[table_name]:
+        raise ValueError(f"Invalid column name: {column_name}")
+
     try:
         with _db_connection(settings) as cnx:
             with cnx.cursor() as cur:
@@ -134,6 +145,12 @@ def _fetch_column_from_table(table_name: str, column_name: str, settings: Settin
 
 def _fetch_random_row(table_name: str, columns: list[str], settings: Settings) -> tuple | None:
     """Fetches a random row for specific columns from a given table."""
+    if table_name not in ALLOWED_TABLES:
+        raise ValueError(f"Invalid table name: {table_name}")
+    for column_name in columns:
+        if column_name not in ALLOWED_TABLES[table_name]:
+            raise ValueError(f"Invalid column name: {column_name}")
+
     try:
         with _db_connection(settings) as cnx:
             with cnx.cursor() as cur:

--- a/tests/test_sayings.py
+++ b/tests/test_sayings.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 import mysql.connector
 import json
 
-from app.sayings.sayings import GetSingleRandSfwS, GetSingleRandNsfwS, GetSingleRandArt, init_db_pool, close_db_pool
+from app.sayings.sayings import GetSingleRandSfwS, GetSingleRandNsfwS, GetSingleRandArt, init_db_pool, close_db_pool, _fetch_column_from_table, _fetch_random_row
 import app.sayings.sayings as say
 from app.config import Settings
 
@@ -88,6 +88,23 @@ class TestSayingFunctions:
 
         with pytest.raises(ConnectionError, match="Database query failed"):
             saying_function(settings=mock_settings_db_enabled)
+
+class TestSayingsValidation:
+    def test_fetch_column_invalid_table(self, mock_settings_db_enabled):
+        with pytest.raises(ValueError, match="Invalid table name: invalid_table"):
+            _fetch_column_from_table("invalid_table", "quote", mock_settings_db_enabled)
+
+    def test_fetch_column_invalid_column(self, mock_settings_db_enabled):
+        with pytest.raises(ValueError, match="Invalid column name: invalid_column"):
+            _fetch_column_from_table("sfw_quotes", "invalid_column", mock_settings_db_enabled)
+
+    def test_fetch_random_row_invalid_table(self, mock_settings_db_enabled):
+        with pytest.raises(ValueError, match="Invalid table name: invalid_table"):
+            _fetch_random_row("invalid_table", ["quote"], mock_settings_db_enabled)
+
+    def test_fetch_random_row_invalid_column(self, mock_settings_db_enabled):
+        with pytest.raises(ValueError, match="Invalid column name: invalid_column"):
+            _fetch_random_row("sfw_quotes", ["quote", "invalid_column"], mock_settings_db_enabled)
 
 class TestPoolFunctions:
     @patch("app.sayings.sayings.pooling.MySQLConnectionPool")


### PR DESCRIPTION
🎯 **What:** Fixed a potential SQL injection vulnerability in `_fetch_column_from_table` and `_fetch_random_row` where table and column names were directly formatted into SQL query strings using f-strings. Added tests in `tests/test_sayings.py` to ensure validation works as intended.

⚠️ **Risk:** While these internal functions were only called with hardcoded identifiers, passing any unsanitized user input in the future would have allowed arbitrary table and column enumeration, or SQL injection leading to data exfiltration or database compromise.

🛡️ **Solution:** Implemented strict schema whitelisting. Added an `ALLOWED_TABLES` dictionary that explicitly maps authorized tables to sets of their allowed columns. Now, any identifier provided to these dynamic query generators must exist in the whitelist; otherwise, a `ValueError` is immediately raised, halting query execution.

---
*PR created automatically by Jules for task [1141602014120883208](https://jules.google.com/task/1141602014120883208) started by @qsig-a*