### PR TITLE
🧹 Remove unused EMPTY_CELL constant

### DIFF
--- a/app/games/boggle.py
+++ b/app/games/boggle.py
@@ -6,7 +6,6 @@ from typing import List, Tuple, Dict, Any
 LETTER_PLACEHOLDER = 1  # Indicates where a rolled letter should be placed
 BOUNDARY_START = 66     # Initial value for boundary cells in the 'start' grid
 BOUNDARY_END = 63       # Value for boundary cells in the 'end' grid
-EMPTY_CELL = 0          # Represents an empty cell in the template
 ASCII_LOWERCASE_OFFSET = 96 # Offset to convert 'a'..'z' to 1..26 (ord('a') - 1)
 
 # --- Boggle Dice Definitions ---


### PR DESCRIPTION
🎯 **What:** Removed the unused `EMPTY_CELL` constant from `app/games/boggle.py`.
💡 **Why:** This constant was defined but never referenced anywhere in the file. Removing dead code reduces clutter and improves readability.
✅ **Verification:** Verified the code health issue was resolved. Ran linting (`poetry run ruff check`) and the test suite (`pytest tests/test_boggle.py`) to confirm no regressions were introduced.
✨ **Result:** A slightly cleaner and more maintainable `app/games/boggle.py` file with no functional changes.

---
*PR created automatically by Jules for task [10698629018990466982](https://jules.google.com/task/10698629018990466982) started by @qsig-a*