### PR TITLE
🧹 [code health] Use tuple for CHAR_CODE_ARRAY

### DIFF
--- a/app/connectors/vestaboard.py
+++ b/app/connectors/vestaboard.py
@@ -44,10 +44,11 @@ CHAR_CODE_MAP = {
 # ⚡ Bolt: Precomputed lookup array for converting byte values directly to Vestaboard
 # character codes. Indexed by the character's ord() value, drastically reducing method
 # lookup overhead in loops from O(1) hashing to direct array access.
-_CHAR_CODE_ARRAY = [0] * 256
+_char_code_list = [0] * 256
 for char, code in CHAR_CODE_MAP.items():
     if ord(char) < 256:
-        _CHAR_CODE_ARRAY[ord(char)] = code
+        _char_code_list[ord(char)] = code
+_CHAR_CODE_ARRAY = tuple(_char_code_list)
 
 class VestaboardConnector:
     """


### PR DESCRIPTION
🎯 **What:** The `_CHAR_CODE_ARRAY` in `app/connectors/vestaboard.py` is now converted to a tuple after its initialization loop.

💡 **Why:** Once initialized, `_CHAR_CODE_ARRAY` is never modified. Making it a tuple after construction is safer (prevents accidental modification) and slightly more memory-efficient.

✅ **Verification:** Ran `poetry run ruff check` and `poetry run pytest`. All format/lint checks and tests passed. Lookups on a tuple perform identically to list lookups in `convert_text_to_array`.

✨ **Result:** Improved maintainability and immutability guarantees without changing behavior.

---
*PR created automatically by Jules for task [13213712684563674909](https://jules.google.com/task/13213712684563674909) started by @qsig-a*