### PR TITLE
🧹 [Type Hint] Use modern type hints in GetSingleRandArt

### DIFF
--- a/app/sayings/sayings.py
+++ b/app/sayings/sayings.py
@@ -187,7 +187,7 @@ def GetSingleRandNsfwS(settings: Settings) -> str | None: # Reverted
          return None # Or raise an exception if preferred
     return _fetch_column_from_table("nsfw_quotes", "quote", settings)
 
-def GetSingleRandArt(settings: Settings) -> tuple[list, str] | None:
+def GetSingleRandArt(settings: Settings) -> tuple[list[list[int]], str] | None:
     """
     Gets a random Art array and title using provided application settings.
     Returns a tuple (art_data, title) or None if not found or on error.


### PR DESCRIPTION
🎯 **What:** Updated the return type hint in `GetSingleRandArt` from `tuple[list, str] | None` to `tuple[list[list[int]], str] | None`.

💡 **Why:** Python 3.10+ supports modern type hints like `list[type]`. Updating `list` to `list[list[int]]` improves type specificity and consistency with the rest of the application, ensuring better code health, readability, and static analysis without altering runtime behavior.

✅ **Verification:** Verified that `poetry run ruff check` and `poetry run pytest` pass successfully.

✨ **Result:** Improved codebase maintainability with accurate and modern type definitions.

---
*PR created automatically by Jules for task [13659479858393218469](https://jules.google.com/task/13659479858393218469) started by @qsig-a*