### PR TITLE
🧪 [testing improvement] Add test for init_db_pool mysql.connector.Error path

### DIFF
--- a/tests/test_sayings.py
+++ b/tests/test_sayings.py
@@ -139,6 +139,15 @@ class TestPoolFunctions:
         close_db_pool()
         assert say._connection_pool is None
 
+    @patch("app.sayings.sayings.pooling.MySQLConnectionPool")
+    @patch("app.sayings.sayings.log.error")
+    def test_init_db_pool_mysql_error(self, mock_log_error, mock_pool, mock_settings_db_enabled):
+        mock_pool.side_effect = mysql.connector.Error("Simulated pool initialization error")
+        say._connection_pool = None
+        init_db_pool(mock_settings_db_enabled)
+        mock_log_error.assert_called_once_with("Error initializing connection pool: Simulated pool initialization error")
+        assert say._connection_pool is None
+
 class TestArtFunctions:
     def test_db_disabled(self, mock_settings_db_disabled):
         with patch("app.sayings.sayings._fetch_random_row") as mock_fetch:


### PR DESCRIPTION
🎯 **What:** The testing gap in `app/sayings/sayings.py` where `init_db_pool` catches a `mysql.connector.Error` was unverified by tests.
📊 **Coverage:** A new test case `test_init_db_pool_mysql_error` was added to `tests/test_sayings.py` under the `TestPoolFunctions` class. This scenario successfully mocks a failure in the `MySQLConnectionPool` initialization by asserting that a `mysql.connector.Error` is properly caught, logged via `log.error`, and that the `_connection_pool` remains `None`.
✨ **Result:** Enhanced test coverage around database pool initialization, ensuring the application gracefully handles and logs initial database connection failures.

---
*PR created automatically by Jules for task [12087424603283454326](https://jules.google.com/task/12087424603283454326) started by @qsig-a*