### PR TITLE
🧪 [testing improvement] Add tests for _post_rw error paths

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,11 @@
+1. **Understand the problem**:
+   The `test_vestaboard_connector.py` file lacks tests for the error paths in `_post_rw`, specifically handling `httpx.HTTPStatusError` and `httpx.RequestError`.
+   The task requires implementing these tests.
+
+2. **Add tests for `_post_rw` error paths**:
+   - Add a test `test_post_rw_http_error` to simulate a `httpx.HTTPStatusError`.
+   - Add a test `test_post_rw_request_error` to simulate a `httpx.RequestError`.
+   - Ensure the mocked `httpx.AsyncClient` raises the expected exceptions and the `VestaboardConnector` wraps them in a `VestaboardError`.
+
+3. **Verify the tests pass**:
+   - Run `poetry run pytest tests/test_vestaboard_connector.py` to ensure the new tests pass and no regressions occur.

--- a/tests/test_vestaboard_connector.py
+++ b/tests/test_vestaboard_connector.py
@@ -78,3 +78,42 @@ async def test_send_array_local_with_options(real_settings):
     assert payload['strategy'] == "column"
     assert payload['step_size'] == 2
     assert payload['characters'] == chars
+
+@pytest.mark.asyncio
+async def test_post_rw_http_error(real_settings):
+    import httpx
+    from app.connectors.vestaboard import VestaboardError
+
+    connector = VestaboardConnector(real_settings)
+
+    # Create a mock response with an error status
+    mock_response = httpx.Response(status_code=400, request=httpx.Request("POST", "/"), text="Bad Request")
+
+    # Mock the client's post method to raise an HTTPStatusError
+    connector._rw_client.post = AsyncMock(side_effect=httpx.HTTPStatusError(
+        "Error", request=mock_response.request, response=mock_response
+    ))
+
+    with pytest.raises(VestaboardError) as exc_info:
+        await connector._post_rw({"text": "Test Error"})
+
+    assert "RW API error: 400" in str(exc_info.value)
+    connector._rw_client.post.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_post_rw_request_error(real_settings):
+    import httpx
+    from app.connectors.vestaboard import VestaboardError
+
+    connector = VestaboardConnector(real_settings)
+
+    # Mock the client's post method to raise a RequestError
+    connector._rw_client.post = AsyncMock(side_effect=httpx.RequestError(
+        "Network Unreachable", request=httpx.Request("POST", "/")
+    ))
+
+    with pytest.raises(VestaboardError) as exc_info:
+        await connector._post_rw({"text": "Test Network Error"})
+
+    assert "RW API network error: Network Unreachable" in str(exc_info.value)
+    connector._rw_client.post.assert_called_once()


### PR DESCRIPTION
🎯 **What:** The error path in `_post_rw` handling `httpx.HTTPStatusError` and `httpx.RequestError` within `app/connectors/vestaboard.py` was completely untested.

📊 **Coverage:** Two new tests have been added:
- `test_post_rw_http_error` to simulate an HTTP-level error and verify `VestaboardError` gets raised with the status code.
- `test_post_rw_request_error` to simulate a network-level RequestError and verify `VestaboardError` gets raised with the network error message.

✨ **Result:** Increased code coverage and confidence that API errors from Vestaboard are correctly wrapped in a uniform error structure for upstream handling.

---
*PR created automatically by Jules for task [15921008272591516300](https://jules.google.com/task/15921008272591516300) started by @qsig-a*