### PR TITLE
⚡ Bolt: Extract inline helper functions to reduce allocation overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Fast JSON decoding for large array structures]
 **Learning:** Decoding large array structures (like 6x22 Vestaboard grid representations) from the database using standard library `json.loads` is a measurable bottleneck (~0.3ms per decode). `pydantic_core.from_json`, which is already available as a dependency, provides a >4x speedup due to its Rust implementation.
 **Action:** For performance-sensitive data fetching, especially large JSON payloads from DB rows, replace standard library `json.loads` with `pydantic_core.from_json`. Make sure to catch `ValueError` instead of `json.JSONDecodeError`.
+
+## 2025-02-13 - Extract Inline Helper Functions
+**Learning:** In high-throughput route handlers (e.g., FastAPI endpoints), defining pure helper functions inline (as closures) causes unnecessary function object allocation overhead on every request.
+**Action:** Define pure helper functions at the module level rather than inline to avoid this overhead.

--- a/app/main.py
+++ b/app/main.py
@@ -124,23 +124,33 @@ async def _get_and_send_base(
         log.exception(f"Unexpected error process: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"{config.error_message}: An unexpected internal error occurred")
 
+def _process_quote(result: str) -> tuple[str, Dict[str, str]]:
+    return result, {}
+
 async def get_and_send_quote(
     config: ActionConfig[str | None],
     settings: Settings,
     connector: VestaboardConnector,
     **kwargs
 ) -> Dict[str, str]:
-    def process_quote(result: str) -> tuple[str, Dict[str, str]]:
-        return result, {}
-
     return await _get_and_send_base(
         config=config,
         settings=settings,
         connector=connector,
         send_method_name="send_message",
-        process_result=process_quote,
+        process_result=_process_quote,
         **kwargs
     )
+
+def _process_art(result) -> tuple[List[List[int]], Dict[str, str]]:
+    title = "Unknown"
+    if isinstance(result, tuple):
+        data, fetched_title = result
+        if fetched_title:
+            title = fetched_title
+    else:
+        data = result
+    return data, {"title": title}
 
 async def get_and_send_art(
     config: ActionConfig[List[List[int]] | tuple[List[List[int]], str] | None],
@@ -148,22 +158,12 @@ async def get_and_send_art(
     connector: VestaboardConnector,
     **kwargs
 ) -> Dict[str, str]:
-    def process_art(result) -> tuple[List[List[int]], Dict[str, str]]:
-        title = "Unknown"
-        if isinstance(result, tuple):
-            data, fetched_title = result
-            if fetched_title:
-                title = fetched_title
-        else:
-            data = result
-        return data, {"title": title}
-
     return await _get_and_send_base(
         config=config,
         settings=settings,
         connector=connector,
         send_method_name="send_array",
-        process_result=process_art,
+        process_result=_process_art,
         **kwargs
     )
 


### PR DESCRIPTION
💡 What: Extracted `process_quote` and `process_art` inline functions out of their respective async route orchestration functions (`get_and_send_quote`, `get_and_send_art`) and moved them to the module level.

🎯 Why: In Python, defining a function inside another function (especially within high-throughput FastAPI route handlers or dependency chains) causes the interpreter to allocate a brand new function object every single time the outer function is executed. Because these helpers are pure functions that don't rely on closure state (they only operate on their input arguments), moving them to the module scope avoids this unnecessary per-request overhead.

📊 Impact: Minor CPU and memory allocation reduction on every request to `/sfw_quote`, `/nsfw_quote`, and `/art` (both RW and local variants). While small per-request, this reduces garbage collection pressure under load.

🔬 Measurement: Run the test suite (`poetry run pytest`) to ensure the functionality remains identical. No regressions were observed.

---
*PR created automatically by Jules for task [6120658917115511673](https://jules.google.com/task/6120658917115511673) started by @qsig-a*