### PR TITLE
🛡️ Sentinel: [security improvement] Secure sensitive configuration with SecretStr

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,16 +1,17 @@
+from pydantic import SecretStr
 from pydantic_settings import BaseSettings
 from typing import Optional
 from functools import lru_cache
 
 class Settings(BaseSettings):
     saying_db_user: Optional[str] = None
-    saying_db_pass: Optional[str] = None
+    saying_db_pass: Optional[SecretStr] = None
     saying_db_host: Optional[str] = None
     saying_db_port: Optional[int] = 3306
     saying_db_name: Optional[str] = None
     saying_db_enable: str = "0" # Default to disabled
-    vestaboard_rw_api_key: Optional[str] = None
-    vestaboard_local_api_key: Optional[str] = None
+    vestaboard_rw_api_key: Optional[SecretStr] = None
+    vestaboard_local_api_key: Optional[SecretStr] = None
     vestaboard_local_api_ip: Optional[str] = None
 
     class Config:

--- a/app/connectors/vestaboard.py
+++ b/app/connectors/vestaboard.py
@@ -57,8 +57,8 @@ class VestaboardConnector:
     """
     def __init__(self, settings: Settings):
         self._settings = settings
-        self._rw_api_key = settings.vestaboard_rw_api_key
-        self._local_api_key = settings.vestaboard_local_api_key
+        self._rw_api_key = settings.vestaboard_rw_api_key.get_secret_value() if settings.vestaboard_rw_api_key else None
+        self._local_api_key = settings.vestaboard_local_api_key.get_secret_value() if settings.vestaboard_local_api_key else None
         self._local_api_ip = settings.vestaboard_local_api_ip
 
         # RW API Client

--- a/app/sayings/sayings.py
+++ b/app/sayings/sayings.py
@@ -48,7 +48,7 @@ def init_db_pool(settings: Settings):
             pool_size=5,
             pool_reset_session=True,
             user=settings.saying_db_user,
-            password=settings.saying_db_pass,
+            password=settings.saying_db_pass.get_secret_value() if settings.saying_db_pass else None,
             host=settings.saying_db_host,
             port=int(settings.saying_db_port),
             database=settings.saying_db_name,
@@ -98,7 +98,7 @@ def _db_connection(settings: Settings):
             # Fallback for testing or if pool initialization failed
             cnx = mysql.connector.connect(
                 user=settings.saying_db_user,
-                password=settings.saying_db_pass,
+                password=settings.saying_db_pass.get_secret_value() if settings.saying_db_pass else None,
                 host=settings.saying_db_host,
                 port=int(settings.saying_db_port),
                 database=settings.saying_db_name,

--- a/tests/test_sayings.py
+++ b/tests/test_sayings.py
@@ -6,6 +6,7 @@ import json
 from app.sayings.sayings import GetSingleRandSfwS, GetSingleRandNsfwS, GetSingleRandArt, init_db_pool, close_db_pool, _fetch_column_from_table, _fetch_random_row
 import app.sayings.sayings as say
 from app.config import Settings
+from pydantic import SecretStr
 
 @pytest.fixture
 def mock_settings_db_enabled() -> Settings:
@@ -13,7 +14,7 @@ def mock_settings_db_enabled() -> Settings:
     return Settings(
         saying_db_enable="1",
         saying_db_user="testuser",
-        saying_db_pass="testpass",
+        saying_db_pass=SecretStr("testpass"),
         saying_db_host="testhost",
         saying_db_port=3306,
         saying_db_name="testdb"
@@ -116,7 +117,7 @@ class TestPoolFunctions:
             pool_size=5,
             pool_reset_session=True,
             user=mock_settings_db_enabled.saying_db_user,
-            password=mock_settings_db_enabled.saying_db_pass,
+            password=mock_settings_db_enabled.saying_db_pass.get_secret_value(),
             host=mock_settings_db_enabled.saying_db_host,
             port=mock_settings_db_enabled.saying_db_port,
             database=mock_settings_db_enabled.saying_db_name,

--- a/tests/test_vestaboard_connector.py
+++ b/tests/test_vestaboard_connector.py
@@ -4,11 +4,13 @@ from unittest.mock import AsyncMock
 from app.connectors.vestaboard import VestaboardConnector, VestaboardError
 from app.config import Settings
 
+from pydantic import SecretStr
+
 @pytest.fixture
 def real_settings():
     settings = Settings()
-    settings.vestaboard_rw_api_key = "rw_key"
-    settings.vestaboard_local_api_key = "local_key"
+    settings.vestaboard_rw_api_key = SecretStr("rw_key")
+    settings.vestaboard_local_api_key = SecretStr("local_key")
     settings.vestaboard_local_api_ip = "192.168.1.100"
     return settings
 


### PR DESCRIPTION
🚨 **Severity**: MEDIUM

💡 **Vulnerability**: Sensitive configuration variables, such as API keys and database passwords, were stored as plain strings in the Pydantic `Settings` model.

🎯 **Impact**: If the `Settings` object was ever accidentally logged, serialized, or printed (e.g., during an error or debugging), the plaintext secrets could be leaked into logs or error tracking systems.

🔧 **Fix**: Updated `saying_db_pass`, `vestaboard_rw_api_key`, and `vestaboard_local_api_key` to use `pydantic.SecretStr` in `app/config.py`. Updated downstream dependencies in `app/connectors/vestaboard.py` and `app/sayings/sayings.py` to safely extract the value using `.get_secret_value()`. Updated test fixtures to supply mock `SecretStr` objects.

✅ **Verification**: Run `poetry run pytest` and `poetry run ruff check --select S app/` to verify tests pass and no security scanning alerts are raised.

---
*PR created automatically by Jules for task [8279570017885908732](https://jules.google.com/task/8279570017885908732) started by @qsig-a*