### PR TITLE
🛡️ Sentinel: [security improvement] Add upper limits to board configuration

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -7,8 +7,8 @@ class LocalBoardOptions:
     def __init__(
         self,
         strategy: Optional[str] = Query(None, max_length=50, description="Transition strategy"),
-        step_interval_ms: Optional[int] = Query(None, ge=0, description="Interval between steps in ms"),
-        step_size: Optional[int] = Query(None, ge=0, description="Number of changes per step")
+        step_interval_ms: Optional[int] = Query(None, ge=0, le=10000, description="Interval between steps in ms"),
+        step_size: Optional[int] = Query(None, ge=0, le=132, description="Number of changes per step")
     ):
         self.strategy = strategy
         self.step_interval_ms = step_interval_ms
@@ -20,5 +20,5 @@ class BoggleClass(BaseModel):
 class MessageClass(BaseModel):
     message: str = Field(..., max_length=1024, description="The message text to display")
     strategy: Optional[str] = Field(None, max_length=50, description="Transition strategy")
-    step_interval_ms: Optional[int] = Field(None, ge=0, description="Interval between steps in ms")
-    step_size: Optional[int] = Field(None, ge=0, description="Number of changes per step")
+    step_interval_ms: Optional[int] = Field(None, ge=0, le=10000, description="Interval between steps in ms")
+    step_size: Optional[int] = Field(None, ge=0, le=132, description="Number of changes per step")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `step_interval_ms` and `step_size` parameters in `LocalBoardOptions` and `MessageClass` lacked upper boundaries. While lower bounds (`ge=0`) were enforced, an attacker could potentially pass excessively large integers, leading to resource exhaustion (Denial of Service) when these parameters are processed by the Vestaboard API or local background tasks.
🎯 Impact: An attacker could degrade or crash the service by submitting requests with enormous intervals or step sizes, tying up async tasks or external API handlers indefinitely.
🔧 Fix: Added reasonable upper constraints using Pydantic's `le` parameter in `app/models.py`. Set `step_interval_ms` max to 10000 (10 seconds) and `step_size` max to 132 (total characters on a standard 6x22 Vestaboard).
✅ Verification: Ran `poetry run pytest` and `poetry run ruff check --select S app/` locally. Tests passed and no regressions or security alerts were found. The validation correctly yields a 422 Unprocessable Entity status code when exceeded.

---
*PR created automatically by Jules for task [4242273085462179957](https://jules.google.com/task/4242273085462179957) started by @qsig-a*