### PR TITLE
🛡️ Sentinel: [security improvement] Add Referrer-Policy header

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -81,7 +81,9 @@ class SecurityHeadersMiddleware:
             (b"x-frame-options", b"DENY"),
             (b"x-xss-protection", b"1; mode=block"),
             (b"strict-transport-security", b"max-age=31536000; includeSubDomains"),
-            (b"content-security-policy", b"default-src 'none'")
+            (b"content-security-policy", b"default-src 'none'"),
+            # 🛡️ Sentinel: Instruct browsers not to send the Referer header to prevent leaking application URLs
+            (b"referrer-policy", b"no-referrer")
         ]
 
     async def __call__(self, scope, receive, send):


### PR DESCRIPTION
### 🚨 Severity: LOW / ENHANCEMENT
### 💡 Vulnerability: Missing `Referrer-Policy` security header
### 🎯 Impact: Without a strong Referrer-Policy, the browser may leak the application's URL or potentially sensitive query parameters to other sites or third parties in the `Referer` header of any outbound requests triggered from the API context (e.g., if rendering an error page with links, though less applicable here, it is a recommended defense-in-depth API default).
### 🔧 Fix: Appended `(b"referrer-policy", b"no-referrer")` to the `SecurityHeadersMiddleware` list in `app/main.py` using ASGI compliant byte strings.
### ✅ Verification: The unit tests and SAST linters passed successfully (`poetry run ruff check --select S app/` and `poetry run pytest`).

---
*PR created automatically by Jules for task [2574171512367861028](https://jules.google.com/task/2574171512367861028) started by @qsig-a*