### PR TITLE
fix: re-route Uvicorn INFO messages away from uvicorn.error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,17 @@ from app.connectors.vestaboard import (
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
+class UvicornInfoFilter(logging.Filter):
+    def filter(self, record):
+        if record.name == "uvicorn.error" and record.levelno < logging.WARNING:
+            record.name = "uvicorn.info"
+        return True
+
+_uvicorn_filter = UvicornInfoFilter()
+for handler in logging.root.handlers:
+    handler.addFilter(_uvicorn_filter)
+logging.getLogger("uvicorn.error").addFilter(_uvicorn_filter)
+
 T = TypeVar('T')
 T_Data = TypeVar('T_Data')
 


### PR DESCRIPTION
### Problem
Uvicorn routes application startup messages (e.g., `Started server process`, `Waiting for application startup.`) through its internal `uvicorn.error` logger, even when they are `INFO`-level messages. This pollutes error logs and makes it confusing to monitor.

### Solution
Created `UvicornInfoFilter` in `app/main.py` which inherits from `logging.Filter`. This filter checks if a log record comes from `uvicorn.error` and is an `INFO` or `DEBUG` message (level < `WARNING`). If so, it renames the logger to `uvicorn.info`. This ensures that actual errors stay in `.error` while informative messages are properly categorized. The filter is added directly to `logging.root.handlers` and `logging.getLogger("uvicorn.error")`.

---
*PR created automatically by Jules for task [16606593415196351169](https://jules.google.com/task/16606593415196351169) started by @qsig-a*