### PR TITLE
🧪 improve test coverage for close_db_pool

### DIFF
--- a/app/sayings/sayings.py
+++ b/app/sayings/sayings.py
@@ -61,9 +61,9 @@ def init_db_pool(settings: Settings):
         log.error(f"Database configuration error for pool: {verr}")
 
 def close_db_pool():
-    """Closes the connection pool (no direct method, just cleanup reference)."""
+    """Closes the database connection pool."""
     global _connection_pool
-    if _connection_pool:
+    if _connection_pool is not None:
         # Note: MySQLConnectionPool does not have a close() method.
         # Connections returned to the pool are closed when the pool object is garbage collected.
         _connection_pool = None

--- a/tests/test_sayings.py
+++ b/tests/test_sayings.py
@@ -140,6 +140,18 @@ class TestPoolFunctions:
         close_db_pool()
         assert say._connection_pool is None
 
+    def test_close_db_pool_when_none(self):
+        say._connection_pool = None
+        # Should not raise any error
+        close_db_pool()
+        assert say._connection_pool is None
+
+    @patch("app.sayings.sayings.log.info")
+    def test_close_db_pool_logging(self, mock_log_info):
+        say._connection_pool = MagicMock()
+        close_db_pool()
+        mock_log_info.assert_called_with("Database connection pool reference cleared.")
+
     @patch("app.sayings.sayings.pooling.MySQLConnectionPool")
     @patch("app.sayings.sayings.log.error")
     def test_init_db_pool_mysql_error(self, mock_log_error, mock_pool, mock_settings_db_enabled):


### PR DESCRIPTION
🎯 **What:** The testing gap for `close_db_pool` addressed by adding explicit cases for already-cleared pools and logging.
📊 **Coverage:** Added tests for `None` pool handling and informational logging.
✨ **Result:** Improved robustness and verification of the database pool cleanup process.

---
*PR created automatically by Jules for task [9301089555321200483](https://jules.google.com/task/9301089555321200483) started by @qsig-a*