### PR TITLE
🛡️ Sentinel: [HIGH] Fix SQL Injection in sayings.py

### DIFF
--- a/app/sayings/sayings.py
+++ b/app/sayings/sayings.py
@@ -149,10 +149,12 @@ def _fetch_column_from_table(table_name: str, column_name: str, settings: Settin
     result = _fetch_random_row(table_name, (column_name,), settings)
 
     if result and result[0] is not None:
-        log.debug(f"Value found in {table_name}.{column_name}.")
+        # 🛡️ Sentinel: Use repr() to prevent log injection.
+        log.debug(f"Value found in {repr(table_name)}.{repr(column_name)}.")
         return str(result[0])
     else:
-        log.warning(f"No value found in table {table_name} or result was NULL.")
+        # 🛡️ Sentinel: Use repr() to prevent log injection.
+        log.warning(f"No value found in table {repr(table_name)} or result was NULL.")
         return None
 
 def _fetch_random_row(table_name: str, columns: tuple[str, ...], settings: Settings) -> tuple | None:
@@ -183,8 +185,9 @@ def _fetch_random_row(table_name: str, columns: tuple[str, ...], settings: Setti
                 cur.execute(query)
                 return cur.fetchone()
     except mysql.connector.Error as err:
-        log.error(f"Database query error in {table_name}: {err}")
-        raise ConnectionError(f"Database query failed for {table_name}") from err
+        # 🛡️ Sentinel: Use repr() to prevent log injection.
+        log.error(f"Database query error in {repr(table_name)}: {err}")
+        raise ConnectionError(f"Database query failed for {repr(table_name)}") from err
 
 # --- Public Functions ---
 

--- a/app/sayings/sayings.py
+++ b/app/sayings/sayings.py
@@ -20,7 +20,28 @@ ALLOWED_TABLES = {
     "art": {"id", "art_data", "title"},
 }
 
-_query_cache: dict[tuple[str, tuple[str, ...]], str] = {}
+# 🛡️ Sentinel: Pre-defined static SQL queries to prevent SQL injection vulnerabilities
+# that can arise from dynamic query construction (even with allowlists).
+_STATIC_QUERIES: dict[tuple[str, tuple[str, ...]], str] = {
+    ("sfw_quotes", ("quote",)): (
+        "SELECT t1.quote FROM sfw_quotes AS t1 "
+        "JOIN (SELECT id FROM sfw_quotes WHERE id >= "
+        "(SELECT FLOOR(RAND() * (MAX(id) - MIN(id) + 1)) + MIN(id) FROM sfw_quotes) "
+        "ORDER BY id LIMIT 1) AS t2 ON t1.id = t2.id"
+    ),
+    ("nsfw_quotes", ("quote",)): (
+        "SELECT t1.quote FROM nsfw_quotes AS t1 "
+        "JOIN (SELECT id FROM nsfw_quotes WHERE id >= "
+        "(SELECT FLOOR(RAND() * (MAX(id) - MIN(id) + 1)) + MIN(id) FROM nsfw_quotes) "
+        "ORDER BY id LIMIT 1) AS t2 ON t1.id = t2.id"
+    ),
+    ("art", ("art_data", "title")): (
+        "SELECT t1.art_data, t1.title FROM art AS t1 "
+        "JOIN (SELECT id FROM art WHERE id >= "
+        "(SELECT FLOOR(RAND() * (MAX(id) - MIN(id) + 1)) + MIN(id) FROM art) "
+        "ORDER BY id LIMIT 1) AS t2 ON t1.id = t2.id"
+    ),
+}
 
 def init_db_pool(settings: Settings):
     """Initializes the MySQL connection pool."""
@@ -137,18 +158,23 @@ def _fetch_column_from_table(table_name: str, column_name: str, settings: Settin
 def _fetch_random_row(table_name: str, columns: tuple[str, ...], settings: Settings) -> tuple | None:
     """Fetches a random row for specific columns from a given table."""
     cache_key = (table_name, columns)
-    query = _query_cache.get(cache_key)
+    query = _STATIC_QUERIES.get(cache_key)
 
     if not query:
+        # 🛡️ Sentinel: Validate input and prevent SQL injection.
+        # We use repr() when logging or raising exceptions with untrusted input to prevent log injection.
         if table_name not in ALLOWED_TABLES:
-            raise ValueError(f"Invalid table name: {table_name}")
+            log.warning(f"Invalid table access attempt: {repr(table_name)}")
+            raise ValueError(f"Invalid table name: {repr(table_name)}")
         for column_name in columns:
             if column_name not in ALLOWED_TABLES[table_name]:
-                raise ValueError(f"Invalid column name: {column_name}")
-        cols_str = ", ".join([f"t1.{c}" for c in columns])
-        # Optimized approach: avoid full table scan by using an inner join on a random ID
-        query = f'SELECT {cols_str} FROM {table_name} AS t1 JOIN (SELECT id FROM {table_name} WHERE id >= (SELECT FLOOR(RAND() * (MAX(id) - MIN(id) + 1)) + MIN(id) FROM {table_name}) ORDER BY id LIMIT 1) AS t2 ON t1.id = t2.id'  # noqa: S608
-        _query_cache[cache_key] = query
+                log.warning(f"Invalid column access attempt: {repr(column_name)} for table {repr(table_name)}")
+                raise ValueError(f"Invalid column name: {repr(column_name)}")
+
+        # If it is in ALLOWED_TABLES but not in _STATIC_QUERIES, it's a valid schema access
+        # but the query isn't pre-defined. We strictly forbid dynamic construction.
+        log.error(f"No static query defined for table {repr(table_name)} with columns {repr(columns)}")
+        raise ValueError("No static query defined for the requested data.")
 
     try:
         with _db_connection(settings) as cnx:

--- a/tests/test_sayings.py
+++ b/tests/test_sayings.py
@@ -92,19 +92,19 @@ class TestSayingFunctions:
 
 class TestSayingsValidation:
     def test_fetch_column_invalid_table(self, mock_settings_db_enabled):
-        with pytest.raises(ValueError, match="Invalid table name: invalid_table"):
+        with pytest.raises(ValueError, match="Invalid table name: 'invalid_table'"):
             _fetch_column_from_table("invalid_table", "quote", mock_settings_db_enabled)
 
     def test_fetch_column_invalid_column(self, mock_settings_db_enabled):
-        with pytest.raises(ValueError, match="Invalid column name: invalid_column"):
+        with pytest.raises(ValueError, match="Invalid column name: 'invalid_column'"):
             _fetch_column_from_table("sfw_quotes", "invalid_column", mock_settings_db_enabled)
 
     def test_fetch_random_row_invalid_table(self, mock_settings_db_enabled):
-        with pytest.raises(ValueError, match="Invalid table name: invalid_table"):
+        with pytest.raises(ValueError, match="Invalid table name: 'invalid_table'"):
             _fetch_random_row("invalid_table", ("quote",), mock_settings_db_enabled)
 
     def test_fetch_random_row_invalid_column(self, mock_settings_db_enabled):
-        with pytest.raises(ValueError, match="Invalid column name: invalid_column"):
+        with pytest.raises(ValueError, match="Invalid column name: 'invalid_column'"):
             _fetch_random_row("sfw_quotes", ("quote", "invalid_column"), mock_settings_db_enabled)
 
 class TestPoolFunctions:


### PR DESCRIPTION
## Severity
HIGH

## Vulnerability
The `_fetch_random_row` function in `app/sayings/sayings.py` used f-strings to dynamically construct SQL queries with table and column names. This pattern is flagged by SAST tools (like Bandit/Ruff S608) as a potential SQL injection vector because structural SQL elements cannot be parameterized using standard DB-API.

## Impact
If an attacker could influence the `table_name` or `columns` arguments, they could potentially execute arbitrary SQL queries, leading to unauthorized data access or modification. Although there was an allowlist in place, the practice itself is insecure and prone to bypasses if the allowlist is misconfigured or expanded insecurely.

## Fix
Replaced the dynamic string concatenation with a static mapping (`_STATIC_QUERIES`) of pre-defined, safe SQL strings for all allowed table and column combinations. This completely removes runtime query construction for these elements. Additionally, updated logging to use `repr()` for input variables to prevent log injection (CRLF) attacks.

## Verification
- Ran `poetry run ruff check --select S app/` and verified that no security issues (including S608) are flagged.
- Manually verified that the pre-defined queries match the previous dynamic generation logic.
- Verified the logic against existing tests in `tests/test_sayings.py`.

---
*PR created automatically by Jules for task [3391393042134682884](https://jules.google.com/task/3391393042134682884) started by @qsig-a*