### PR TITLE
🧹 [Code Health] Fix duplicate mysql.connector import in sayings.py

### DIFF
--- a/app/sayings/sayings.py
+++ b/app/sayings/sayings.py
@@ -1,6 +1,5 @@
 
-import mysql.connector
-from mysql.connector import pooling
+from mysql.connector import pooling, Error, PoolError, connect
 import logging
 from pydantic_core import from_json
 from contextlib import contextmanager
@@ -76,7 +75,7 @@ def init_db_pool(settings: Settings):
             connection_timeout=5
         )
         log.info("Database connection pool initialized.")
-    except mysql.connector.Error as err:
+    except Error as err:
         log.error(f"Error initializing connection pool: {err}")
     except ValueError as verr:
         log.error(f"Database configuration error for pool: {verr}")
@@ -117,7 +116,7 @@ def _db_connection(settings: Settings):
             log.debug("Obtained connection from pool.")
         else:
             # Fallback for testing or if pool initialization failed
-            cnx = mysql.connector.connect(
+            cnx = connect(
                 user=settings.saying_db_user,
                 password=settings.saying_db_pass.get_secret_value() if settings.saying_db_pass else None,
                 host=settings.saying_db_host,
@@ -127,10 +126,10 @@ def _db_connection(settings: Settings):
             )
             log.debug("Database connection successful (no pool).")
         yield cnx
-    except mysql.connector.PoolError as err:
+    except PoolError as err:
         log.error(f"Error getting connection from pool: {err}")
         raise ConnectionError(f"Database connection pool exhausted: {err}") from err
-    except mysql.connector.Error as err:
+    except Error as err:
         log.error(f"Error connecting to database: {err}")
         raise ConnectionError(f"Database connection failed: {err}") from err
     except ValueError as verr:
@@ -141,7 +140,7 @@ def _db_connection(settings: Settings):
             try:
                 cnx.close()
                 log.debug("Database connection returned to pool or closed.")
-            except mysql.connector.Error as err:
+            except Error as err:
                 log.warning(f"Error closing connection/returning to pool: {err}")
 
 def _fetch_column_from_table(table_name: str, column_name: str, settings: Settings) -> str | None:
@@ -184,7 +183,7 @@ def _fetch_random_row(table_name: str, columns: tuple[str, ...], settings: Setti
                 log.debug(f"Executing query: {query}")
                 cur.execute(query)
                 return cur.fetchone()
-    except mysql.connector.Error as err:
+    except Error as err:
         # 🛡️ Sentinel: Use repr() to prevent log injection.
         log.error(f"Database query error in {repr(table_name)}: {err}")
         raise ConnectionError(f"Database query failed for {repr(table_name)}") from err

--- a/benchmark.py
+++ b/benchmark.py
@@ -2,11 +2,12 @@ import time
 from unittest.mock import MagicMock
 from app.config import get_settings
 import app.sayings.sayings
+from pydantic import SecretStr
 
 settings = get_settings()
 settings.saying_db_enable = '1'
 settings.saying_db_user = 'testuser'
-settings.saying_db_pass = 'testpass'
+settings.saying_db_pass = SecretStr('testpass')
 settings.saying_db_host = 'testhost'
 settings.saying_db_port = 3306
 settings.saying_db_name = 'testdb'
@@ -21,8 +22,8 @@ def mock_connect(*args, **kwargs):
     time.sleep(0.01) # Simulate network/connection latency
     return mock_db_conn
 
-app.sayings.sayings.mysql = MagicMock()
-app.sayings.sayings.mysql.connector.connect.side_effect = mock_connect
+app.sayings.sayings.connect = MagicMock()
+app.sayings.sayings.connect.side_effect = mock_connect
 
 # 1. Test without pool (baseline)
 # Force clear pool to simulate old behavior


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the duplicate `import mysql.connector` in `app/sayings/sayings.py` by converting usages of `mysql.connector.Error`, `mysql.connector.PoolError`, and `mysql.connector.connect` to explicit imports from `mysql.connector`.

💡 **Why:** How this improves maintainability
The duplicate import was unnecessary clutter. Centralizing imports at the top using `from mysql.connector import pooling, Error, PoolError, connect` improves readability and maintains clean namespace usage.

✅ **Verification:** How you confirmed the change is safe
- Executed the `pytest` test suite, which passed successfully.
- Manually verified `benchmark.py` executed successfully, ensuring mocks still work correctly after the import change.
- Executed the `ruff check` linter, ensuring syntax and stylistic correctness.

✨ **Result:** The improvement achieved
A cleaner module-level import configuration in `app/sayings/sayings.py` without breaking any downstream dependencies or mocking integrations.

---
*PR created automatically by Jules for task [14632707349021808001](https://jules.google.com/task/14632707349021808001) started by @qsig-a*