### PR TITLE
🛡️ Sentinel: [security improvement] Hardened SecurityHeadersMiddleware

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -94,7 +94,11 @@ class SecurityHeadersMiddleware:
             (b"strict-transport-security", b"max-age=31536000; includeSubDomains"),
             (b"content-security-policy", b"default-src 'none'"),
             # 🛡️ Sentinel: Instruct browsers not to send the Referer header to prevent leaking application URLs
-            (b"referrer-policy", b"no-referrer")
+            (b"referrer-policy", b"no-referrer"),
+            # 🛡️ Sentinel: Prevent caching of API responses
+            (b"cache-control", b"no-store, no-cache, must-revalidate, max-age=0"),
+            # 🛡️ Sentinel: Mask the 'server' header to prevent technology stack information disclosure (Uvicorn adds it if omitted)
+            (b"server", b"hidden")
         ]
 
     async def __call__(self, scope, receive, send):
@@ -105,6 +109,8 @@ class SecurityHeadersMiddleware:
             if message["type"] == "http.response.start":
                 # Ensure compliance with ASGI spec (list of tuples)
                 headers = list(message.get("headers", []))
+                # Remove existing 'server' headers to prevent duplicates
+                headers = [h for h in headers if h[0].lower() != b"server"]
                 headers.extend(self._headers)
                 message["headers"] = headers
             await send(message)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unintended caching of sensitive API responses and technology stack information disclosure via the default Uvicorn `Server` header.
🎯 **Impact:** Exposes the underlying application server version (aiding potential attackers in fingerprinting the stack) and risks exposing API response data in intermediary caches.
🔧 **Fix:** 
- Stripped the default `server` header and replaced it with a masked value (`hidden`) in `SecurityHeadersMiddleware`.
- Added the `Cache-Control: no-store, no-cache, must-revalidate, max-age=0` header to prevent browser and proxy caching of unauthenticated API endpoints.
✅ **Verification:** Ran a temporary test script leveraging `fastapi.testclient.TestClient` to verify the presence of the `cache-control` header and the successful masking of the `server` header. Additionally ran `poetry run pytest` to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [12394426172878987777](https://jules.google.com/task/12394426172878987777) started by @qsig-a*