### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limiting on unauthenticated quote/art endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass
 from typing import List, Dict, Callable, Awaitable, TypeVar, Generic, Any
 
@@ -66,8 +67,6 @@ async def lifespan(app: FastAPI):
             log.info("Vestaboard connector closed.")
         else:
             log.warning("Vestaboard connector not found during shutdown.")
-
-import time
 
 _rate_limit_lock = asyncio.Lock()
 _last_request_time = 0.0
@@ -334,7 +333,8 @@ _ART_LOCAL_CONFIG = ActionConfig(
 @app.get("/sfw_quote")
 async def get_sfw_quote(
     settings: Settings = Depends(get_settings),
-    connector: VestaboardConnector = Depends(get_vestaboard_connector)
+    connector: VestaboardConnector = Depends(get_vestaboard_connector),
+    _: None = Depends(rate_limiter)
 ) -> Dict[str, str]:
     return await get_and_send_quote(
         config=_SFW_QUOTE_CONFIG,
@@ -346,7 +346,8 @@ async def get_sfw_quote(
 async def get_sfw_quote_local(
     options: LocalBoardOptions = Depends(),
     settings: Settings = Depends(get_settings),
-    connector: VestaboardConnector = Depends(get_vestaboard_connector)
+    connector: VestaboardConnector = Depends(get_vestaboard_connector),
+    _: None = Depends(rate_limiter)
 ) -> Dict[str, str]:
     return await get_and_send_quote(
         config=_SFW_QUOTE_LOCAL_CONFIG,
@@ -360,7 +361,8 @@ async def get_sfw_quote_local(
 @app.get("/nsfw_quote")
 async def get_nsfw_quote(
     settings: Settings = Depends(get_settings),
-    connector: VestaboardConnector = Depends(get_vestaboard_connector)
+    connector: VestaboardConnector = Depends(get_vestaboard_connector),
+    _: None = Depends(rate_limiter)
 ) -> Dict[str, str]:
     return await get_and_send_quote(
         config=_NSFW_QUOTE_CONFIG,
@@ -372,7 +374,8 @@ async def get_nsfw_quote(
 async def get_nsfw_quote_local(
     options: LocalBoardOptions = Depends(),
     settings: Settings = Depends(get_settings),
-    connector: VestaboardConnector = Depends(get_vestaboard_connector)
+    connector: VestaboardConnector = Depends(get_vestaboard_connector),
+    _: None = Depends(rate_limiter)
 ) -> Dict[str, str]:
     return await get_and_send_quote(
         config=_NSFW_QUOTE_LOCAL_CONFIG,
@@ -386,7 +389,8 @@ async def get_nsfw_quote_local(
 @app.get("/art")
 async def get_random_art(
     settings: Settings = Depends(get_settings),
-    connector: VestaboardConnector = Depends(get_vestaboard_connector)
+    connector: VestaboardConnector = Depends(get_vestaboard_connector),
+    _: None = Depends(rate_limiter)
 ) -> Dict[str, str]:
     return await get_and_send_art(
         config=_ART_CONFIG,
@@ -398,7 +402,8 @@ async def get_random_art(
 async def get_random_art_local(
     options: LocalBoardOptions = Depends(),
     settings: Settings = Depends(get_settings),
-    connector: VestaboardConnector = Depends(get_vestaboard_connector)
+    connector: VestaboardConnector = Depends(get_vestaboard_connector),
+    _: None = Depends(rate_limiter)
 ) -> Dict[str, str]:
     return await get_and_send_art(
         config=_ART_LOCAL_CONFIG,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The unauthenticated endpoints for fetching quotes and art (e.g., `/sfw_quote`, `/art`) did not use the global `rate_limiter` dependency.
🎯 Impact: An attacker could rapidly hit these endpoints to exhaust the Vestaboard API rate limits, or perform a Denial of Service (DoS) attack against the application and Vestaboard API.
🔧 Fix: Injected the existing `rate_limiter` dependency into the endpoints.
✅ Verification: Verified using a custom Python `TestClient` script that a rapid sequence of requests triggers a 429 Too Many Requests response, and ran the full pytest suite.

---
*PR created automatically by Jules for task [3016470342319865643](https://jules.google.com/task/3016470342319865643) started by @qsig-a*