### PR TITLE
🛡️ Sentinel: [security improvement] Correct middleware execution order to enforce security headers on all error paths

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -144,7 +144,6 @@ class SecurityHeadersMiddleware:
 
         await self.app(scope, receive, send_wrapper)
 
-app.add_middleware(SecurityHeadersMiddleware)
 
 # 🛡️ Sentinel: Enforce a global payload size limit of 1MB to prevent resource exhaustion (DoS)
 # attacks from malicious clients sending excessively large request bodies.
@@ -204,7 +203,16 @@ class PayloadSizeLimitMiddleware:
             "body": response_body,
         })
 
+# 🛡️ Sentinel: Middleware order is critical for defense-in-depth.
+# In Starlette/FastAPI, middlewares wrap each other in reverse order of addition.
+# PayloadSizeLimitMiddleware must be added FIRST (so it is the inner layer),
+# and SecurityHeadersMiddleware added LAST (so it is the outermost layer).
+# This ensures that early error responses (like 413 Payload Too Large) generated
+# by inner middlewares still pass through the outer SecurityHeadersMiddleware
+# and receive the necessary security headers (CSP, HSTS, etc.) to prevent
+# vulnerabilities if the browser renders the error response.
 app.add_middleware(PayloadSizeLimitMiddleware)
+app.add_middleware(SecurityHeadersMiddleware)
 
 
 async def handle_vestaboard_action(


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `SecurityHeadersMiddleware` was added before the `PayloadSizeLimitMiddleware`, causing it to act as an inner wrapper instead of an outer wrapper. Because of this, when the `PayloadSizeLimitMiddleware` intercepted an overly large payload and rejected it early with a `413 Payload Too Large` error, the response bypassed the `SecurityHeadersMiddleware` and omitted essential security headers (such as `Content-Security-Policy` and `Strict-Transport-Security`). If a browser was somehow coaxed into rendering the error message, this could present cross-site scripting or downgrade risks.
🎯 **Impact:** Prevents defense-in-depth bypasses on early connection rejections (like 413s or future rate limits that send early responses). Ensures all outgoing application responses reliably contain security headers.
🔧 **Fix:** Reversed the `app.add_middleware()` order in `app/main.py`. In Starlette/FastAPI, the last added middleware is the outermost wrapper. The `SecurityHeadersMiddleware` is now added last, guaranteeing that any HTTP response generated by the inner payload limiting middleware passes through it and is assigned security headers.
✅ **Verification:** Verified by testing early rejection responses locally via test scripts (now cleaned up) which confirm that headers like `x-content-type-options`, `content-security-policy`, and `strict-transport-security` are now present on 413 errors. The full test suite also continues to pass.

---
*PR created automatically by Jules for task [14753073712531927327](https://jules.google.com/task/14753073712531927327) started by @qsig-a*