### PR TITLE
🛡️ Sentinel: [security improvement] Add Retry-After header to 429 response

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -80,10 +80,12 @@ async def rate_limiter():
         now = time.monotonic()
         time_since_last = now - _last_request_time
         if time_since_last < RATE_LIMIT_DELAY:
-            # Optionally sleep, or reject. We choose to reject to avoid hanging clients
+            wait_time = RATE_LIMIT_DELAY - time_since_last
+            # 🛡️ Sentinel: Include Retry-After header in 429 responses to ensure well-behaved clients back off properly
             raise HTTPException(
                 status_code=429,
-                detail=f"Rate limit exceeded. Try again in {RATE_LIMIT_DELAY - time_since_last:.1f} seconds."
+                detail=f"Rate limit exceeded. Try again in {wait_time:.1f} seconds.",
+                headers={"Retry-After": str(int(wait_time) + 1)}
             )
         _last_request_time = time.monotonic()
 
@@ -213,7 +215,6 @@ class PayloadSizeLimitMiddleware:
 # vulnerabilities if the browser renders the error response.
 app.add_middleware(PayloadSizeLimitMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
-
 
 async def handle_vestaboard_action(
     action: Awaitable[T],


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The global rate limiter blocks excessive requests by returning a `429 Too Many Requests` status code, but failed to include a `Retry-After` header. This omission leaves well-behaved clients guessing when they can safely retry, potentially causing them to hammer the server with rapid subsequent requests, exacerbating load during peak times.
🎯 **Impact**: Malicious or misconfigured clients could inadvertently contribute to resource exhaustion by continually polling the API before the rate limit window resets.
🔧 **Fix**: Enhanced the `rate_limiter` dependency in `app/main.py` to calculate the exact remaining delay (`wait_time`) and include a standard `Retry-After` header in the HTTP 429 exception response. The value is rounded up to the nearest integer second. Added explanatory Sentinel comment.
✅ **Verification**: Verified using `poetry run pytest` that all 107 tests pass correctly without regressions.

---
*PR created automatically by Jules for task [16358046616458138036](https://jules.google.com/task/16358046616458138036) started by @qsig-a*