### PR TITLE
🛡️ Sentinel: [security improvement] Prevent log injection in DB errors

### DIFF
--- a/app/sayings/sayings.py
+++ b/app/sayings/sayings.py
@@ -102,9 +102,9 @@ def init_db_pool(settings: Settings):
         )
         log.info("Database connection pool initialized.")
     except Error as err:
-        log.error(f"Error initializing connection pool: {err}")
+        log.error(f"Error initializing connection pool: {repr(err)}")
     except ValueError as verr:
-        log.error(f"Database configuration error for pool: {verr}")
+        log.error(f"Database configuration error for pool: {repr(verr)}")
 
 def close_db_pool():
     """Closes the database connection pool."""
@@ -128,13 +128,13 @@ def _db_connection(settings: Settings):
         cnx = _acquire_connection(settings)
         yield cnx
     except PoolError as err:
-        log.error(f"Error getting connection from pool: {err}")
+        log.error(f"Error getting connection from pool: {repr(err)}")
         raise ConnectionError(f"Database connection pool exhausted: {err}") from err
     except Error as err:
-        log.error(f"Error connecting to database: {err}")
+        log.error(f"Error connecting to database: {repr(err)}")
         raise ConnectionError(f"Database connection failed: {err}") from err
     except ValueError as verr:
-        log.error(f"Database configuration error (e.g., non-integer port): {verr}")
+        log.error(f"Database configuration error (e.g., non-integer port): {repr(verr)}")
         raise ConnectionError(f"Database configuration error: {verr}") from verr
     finally:
         if cnx and cnx.is_connected():
@@ -186,7 +186,7 @@ def _fetch_random_row(table_name: str, columns: tuple[str, ...], settings: Setti
                 return cur.fetchone()
     except Error as err:
         # 🛡️ Sentinel: Use repr() to prevent log injection.
-        log.error(f"Database query error in {repr(table_name)}: {err}")
+        log.error(f"Database query error in {repr(table_name)}: {repr(err)}")
         raise ConnectionError(f"Database query failed for {repr(table_name)}") from err
 
 # --- Public Functions ---
@@ -232,6 +232,6 @@ def GetSingleRandArt(settings: Settings) -> tuple[list[list[int]], str] | None:
                 log.warning("Art data is not a list.")
                 return None
         except ValueError as e:
-            log.error(f"Failed to decode art data: {e}")
+            log.error(f"Failed to decode art data: {repr(e)}")
             return None
     return None

--- a/tests/test_sayings.py
+++ b/tests/test_sayings.py
@@ -177,11 +177,12 @@ class TestPoolFunctions:
     @patch("app.sayings.sayings.pooling.MySQLConnectionPool")
     @patch("app.sayings.sayings.log.error")
     def test_init_db_pool_mysql_error(self, mock_log_error, mock_pool, mock_settings_db_enabled):
-        mock_pool.side_effect = mysql.connector.Error("Simulated pool initialization error")
+        err = mysql.connector.Error("Simulated pool initialization error")
+        mock_pool.side_effect = err
         say._connection_pool = None
         say._db_configured_cache = None
         init_db_pool(mock_settings_db_enabled)
-        mock_log_error.assert_called_once_with("Error initializing connection pool: Simulated pool initialization error")
+        mock_log_error.assert_called_once_with(f"Error initializing connection pool: {repr(err)}")
         assert say._connection_pool is None
 
     @patch("app.sayings.sayings.log.error")
@@ -196,11 +197,12 @@ class TestPoolFunctions:
     @patch("app.sayings.sayings.pooling.MySQLConnectionPool")
     @patch("app.sayings.sayings.log.error")
     def test_init_db_pool_value_error(self, mock_log_error, mock_pool, mock_settings_db_enabled):
-        mock_pool.side_effect = ValueError("Simulated ValueError")
+        err = ValueError("Simulated ValueError")
+        mock_pool.side_effect = err
         say._connection_pool = None
         say._db_configured_cache = None
         init_db_pool(mock_settings_db_enabled)
-        mock_log_error.assert_called_once_with("Database configuration error for pool: Simulated ValueError")
+        mock_log_error.assert_called_once_with(f"Database configuration error for pool: {repr(err)}")
         assert say._connection_pool is None
 
 class TestArtFunctions:


### PR DESCRIPTION
**Context:**
Building on the previous log injection (CRLF) prevention added for external HTTP API responses, this patch extends the defense-in-depth strategy to database connection and execution errors. 

**Vulnerability/Risk:**
If a database server or intermediate proxy returns an error message containing unescaped control characters (e.g., newlines `\n`, `\r`) – potentially triggered by a malicious user input that reached the DB driver, or a compromised/misconfigured server – those characters would be logged directly. This could lead to log spoofing or corruption of the application logs.

**Fix:**
This PR modifies `app/sayings/sayings.py` to wrap the caught exception variables (`err`, `verr`, `e`) in Python's built-in `repr()` function before interpolating them into `log.error()` messages. This safely escapes any control characters within the error string without destroying the context needed for debugging.

The corresponding mock assertions in `tests/test_sayings.py` have been updated to expect the new `repr` format.

**Verification:**
- [x] Code audited manually
- [x] `poetry run pytest` passes (107 tests)
- [x] `poetry run ruff check` passes

---
*PR created automatically by Jules for task [18191308415034815801](https://jules.google.com/task/18191308415034815801) started by @qsig-a*