### PR TITLE
🧹 Extract SecurityHeadersMiddleware to dedicated file

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from app.connectors.vestaboard import (
     VestaboardAuthError,
     VestaboardInvalidCharsError
 )
+from app.middleware.security import SecurityHeadersMiddleware
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -101,51 +102,6 @@ app = FastAPI(
     description="API for controlling Vestaboard, playing games, and getting sayings.",
     lifespan=lifespan
 )
-
-# ⚡ Bolt: Implemented pure ASGI middleware for security headers.
-# Using @app.middleware("http") forces FastAPI to allocate new Request and Response
-# objects for every single HTTP request. A pure ASGI middleware avoids this completely
-# by manipulating the ASGI messages directly, providing a >25% throughput increase.
-class SecurityHeadersMiddleware:
-    def __init__(self, app):
-        self.app = app
-        self._headers = [
-            (b"x-content-type-options", b"nosniff"),
-            (b"x-frame-options", b"DENY"),
-            (b"x-xss-protection", b"1; mode=block"),
-            (b"strict-transport-security", b"max-age=31536000; includeSubDomains"),
-            (b"content-security-policy", b"default-src 'none'"),
-            # 🛡️ Sentinel: Instruct browsers not to send the Referer header to prevent leaking application URLs
-            (b"referrer-policy", b"no-referrer"),
-            # 🛡️ Sentinel: Prevent caching of API responses
-            (b"cache-control", b"no-store, no-cache, must-revalidate, max-age=0"),
-            # 🛡️ Sentinel: Mask the 'server' header to prevent technology stack information disclosure (Uvicorn adds it if omitted)
-            (b"server", b"hidden"),
-            # 🛡️ Sentinel: Restrict browser features via Permissions-Policy to prevent access to sensitive APIs
-            (b"permissions-policy", b"accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"),
-            # 🛡️ Sentinel: Prevent cross-origin resource sharing and cross-origin window opening for API isolation
-            (b"cross-origin-resource-policy", b"same-origin"),
-            (b"cross-origin-opener-policy", b"same-origin"),
-            # 🛡️ Sentinel: Ensure cross-origin isolation by requiring Cross-Origin-Resource-Policy for embeddings
-            (b"cross-origin-embedder-policy", b"require-corp")
-        ]
-
-    async def __call__(self, scope, receive, send):
-        if scope["type"] != "http":
-            return await self.app(scope, receive, send)
-
-        async def send_wrapper(message):
-            if message["type"] == "http.response.start":
-                # Ensure compliance with ASGI spec (list of tuples)
-                headers = list(message.get("headers", []))
-                # Remove existing 'server' headers to prevent duplicates
-                headers = [h for h in headers if h[0].lower() != b"server"]
-                headers.extend(self._headers)
-                message["headers"] = headers
-            await send(message)
-
-        await self.app(scope, receive, send_wrapper)
-
 
 # 🛡️ Sentinel: Enforce a global payload size limit of 1MB to prevent resource exhaustion (DoS)
 # attacks from malicious clients sending excessively large request bodies.

--- a/app/middleware/security.py
+++ b/app/middleware/security.py
@@ -1,0 +1,39 @@
+class SecurityHeadersMiddleware:
+    def __init__(self, app):
+        self.app = app
+        self._headers = [
+            (b"x-content-type-options", b"nosniff"),
+            (b"x-frame-options", b"DENY"),
+            (b"x-xss-protection", b"1; mode=block"),
+            (b"strict-transport-security", b"max-age=31536000; includeSubDomains"),
+            (b"content-security-policy", b"default-src 'none'"),
+            # 🛡️ Sentinel: Instruct browsers not to send the Referer header to prevent leaking application URLs
+            (b"referrer-policy", b"no-referrer"),
+            # 🛡️ Sentinel: Prevent caching of API responses
+            (b"cache-control", b"no-store, no-cache, must-revalidate, max-age=0"),
+            # 🛡️ Sentinel: Mask the 'server' header to prevent technology stack information disclosure (Uvicorn adds it if omitted)
+            (b"server", b"hidden"),
+            # 🛡️ Sentinel: Restrict browser features via Permissions-Policy to prevent access to sensitive APIs
+            (b"permissions-policy", b"accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"),
+            # 🛡️ Sentinel: Prevent cross-origin resource sharing and cross-origin window opening for API isolation
+            (b"cross-origin-resource-policy", b"same-origin"),
+            (b"cross-origin-opener-policy", b"same-origin"),
+            # 🛡️ Sentinel: Ensure cross-origin isolation by requiring Cross-Origin-Resource-Policy for embeddings
+            (b"cross-origin-embedder-policy", b"require-corp")
+        ]
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        async def send_wrapper(message):
+            if message["type"] == "http.response.start":
+                # Ensure compliance with ASGI spec (list of tuples)
+                headers = list(message.get("headers", []))
+                # Remove existing 'server' headers to prevent duplicates
+                headers = [h for h in headers if h[0].lower() != b"server"]
+                headers.extend(self._headers)
+                message["headers"] = headers
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)


### PR DESCRIPTION
🎯 **What:** Extracted `SecurityHeadersMiddleware` from `app/main.py` into its own dedicated file `app/middleware/security.py`.
💡 **Why:** `app/main.py` was becoming overly complex and cluttered with middleware implementation details. Moving it to a dedicated file improves maintainability, readability, and separation of concerns within the codebase.
✅ **Verification:** Verified the refactor by running the full test suite (`poetry run pytest`, 107/107 passed) and manually writing/running a test script to inspect the live response headers to ensure the security headers are still correctly applied to responses.
✨ **Result:** Improved codebase organization and a cleaner, more focused `app/main.py` file without changing any application behavior.

---
*PR created automatically by Jules for task [14022182711273402572](https://jules.google.com/task/14022182711273402572) started by @qsig-a*