### PR TITLE
🧪 Add tests for UvicornInfoFilter

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -652,3 +652,29 @@ def test_get_quote_unexpected_error(
     assert response.status_code == 500
     assert f"{expected_error_msg_prefix}: An unexpected internal error occurred" in response.json()["detail"]
 
+
+# --- Tests for UvicornInfoFilter ---
+import logging
+from app.main import UvicornInfoFilter
+
+def test_uvicorn_info_filter():
+    """Tests that UvicornInfoFilter correctly renames uvicorn.error below WARNING to uvicorn.info."""
+    f = UvicornInfoFilter()
+
+    # Test case 1: name is uvicorn.error, level is INFO
+    record = logging.LogRecord("uvicorn.error", logging.INFO, "pathname", 1, "msg", (), None)
+    result = f.filter(record)
+    assert result is True
+    assert record.name == "uvicorn.info"
+
+    # Test case 2: name is uvicorn.error, level is WARNING
+    record = logging.LogRecord("uvicorn.error", logging.WARNING, "pathname", 1, "msg", (), None)
+    result = f.filter(record)
+    assert result is True
+    assert record.name == "uvicorn.error"
+
+    # Test case 3: name is something else
+    record = logging.LogRecord("other.logger", logging.INFO, "pathname", 1, "msg", (), None)
+    result = f.filter(record)
+    assert result is True
+    assert record.name == "other.logger"


### PR DESCRIPTION
🎯 **What:** `UvicornInfoFilter` in `app/main.py` was completely untested. Added `test_uvicorn_info_filter` to `tests/test_main.py` to ensure it works correctly.

📊 **Coverage:** Now we cover the happy path (changing `uvicorn.error` at level INFO to `uvicorn.info`), negative boundary edge case (keeping `uvicorn.error` at level WARNING untouched) and negative name edge case (keeping other loggers entirely untouched).

✨ **Result:** 100% test coverage on `UvicornInfoFilter` logic.

---
*PR created automatically by Jules for task [12465788894115588113](https://jules.google.com/task/12465788894115588113) started by @qsig-a*