### PR TITLE
🛡️ Sentinel: [HIGH] Fix Container Runs as Root vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,20 @@ RUN pip install --upgrade pip
 # Install Poetry
 RUN pip install poetry
 
+# Create a non-root user and group
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+
+WORKDIR /app
+
 # Copy project files
-ADD app /app
-ADD pyproject.toml pyproject.toml
-ADD poetry.lock poetry.lock
+ADD --chown=appuser:appuser app ./app
+ADD --chown=appuser:appuser pyproject.toml pyproject.toml
+ADD --chown=appuser:appuser poetry.lock poetry.lock
 
 # Install dependencies
 RUN poetry config virtualenvs.create false && poetry install --no-root --only main
 
-CMD [ "poetry", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80" ]
+# Switch to non-root user
+USER appuser
+
+CMD [ "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080" ]

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ You can also run the application using Docker.
 
     **Option A: Passing variables directly**
     ```bash
-    docker run -d -p 8000:80 \
+    docker run -d -p 8000:8080 \
       --env VESTABOARD_RW_API_KEY="your_vestaboard_rw_api_key" \
       --env VESTABOARD_LOCAL_API_KEY="your_vestaboard_local_api_key" \
       --env VESTABOARD_LOCAL_API_IP="192.168.1.100" \
@@ -239,7 +239,7 @@ You can also run the application using Docker.
     **Option B: Using an environment file**
     Create a `.env` file (as described in the "Local Development" setup) in your project root. Then run:
     ```bash
-    docker run -d -p 8000:80 \
+    docker run -d -p 8000:8080 \
       --env-file .env \
       --name home-automation-app \
       home-automation-server


### PR DESCRIPTION
🎯 **What:** The Dockerfile was configured to run the FastAPI application container as the `root` user by default.
⚠️ **Risk:** Running containers as root creates a significant security risk. If a vulnerability in the application or its dependencies were exploited, an attacker would gain root privileges within the container, potentially allowing them to escalate privileges, access the host system, or execute arbitrary code.
🛡️ **Solution:** The Dockerfile was updated to create a non-root user and group (`appuser`). The `WORKDIR` was explicitly set to `/app`, and all project files are now copied with `--chown=appuser:appuser` to ensure correct permissions. The `USER appuser` directive was added to switch the execution context. Because non-root users cannot bind to privileged ports (< 1024), the application now listens on port `8080`. The `README.md` was also updated to instruct users to map their host ports to `8080`. Finally, the `CMD` was updated to invoke `uvicorn` directly instead of via `poetry run` to avoid permission issues with root's poetry configuration files.

---
*PR created automatically by Jules for task [6197945194420743957](https://jules.google.com/task/6197945194420743957) started by @qsig-a*